### PR TITLE
role: mongodb: change mongodb__conf_net_bind_ip

### DIFF
--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,4 +1,5 @@
-mongodb__conf_net_bind_ip: 'localhost'
+mongodb__conf_net_bind_ip:
+  - 'localhost'
 mongodb__conf_net_port: 27017
 mongodb__conf_replication_repl_set_name__dependent_var: ''
 mongodb__conf_replication_repl_set_name__group_var: ''

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -78,7 +78,7 @@
 
   - name: 'Ensure replicaset "{{ mongodb__conf_replication_repl_set_name__combined_var }}" exists'
     community.mongodb.mongodb_replicaset:
-      login_host: '{{ mongodb__conf_net_bind_ip }}'
+      login_host: '{{ mongodb__conf_net_bind_ip[0] }}'
       login_port: '{{ mongodb__conf_net_port }}'
       login_user: '{{ mongodb__admin_user["username"] | default(omit) }}'
       login_password: '{{ mongodb__admin_user["password"] | default(omit) }}'
@@ -92,7 +92,7 @@
 
   - name: 'Wait for the replicaset to stabilise'
     community.mongodb.mongodb_status:
-      login_host: '{{ mongodb__conf_net_bind_ip }}'
+      login_host: '{{ mongodb__conf_net_bind_ip[0] }}'
       login_port: '{{ mongodb__conf_net_port }}'
       login_user: '{{ mongodb__admin_user["username"] | default(omit) }}'
       login_password: '{{ mongodb__admin_user["password"] | default(omit) }}'
@@ -114,7 +114,7 @@
 
   - name: 'check if host is primary and writable'
     community.mongodb.mongodb_shell:
-      login_host: '{{ mongodb__conf_net_bind_ip }}'
+      login_host: '{{ mongodb__conf_net_bind_ip[0] }}'
       login_port: '{{ mongodb__conf_net_port }}'
       eval: 'db.hello().isWritablePrimary'
       mongo_cmd: 'mongosh'
@@ -139,7 +139,7 @@
 
   - name: 'Create DBA "{{ mongodb__admin_user["username"] }}" (if first user, using localhost exception)' # https://www.mongodb.com/docs/manual/core/localhost-exception/
     community.mongodb.mongodb_user:
-      login_host: '{{ mongodb__conf_net_bind_ip }}'
+      login_host: '{{ mongodb__conf_net_bind_ip[0] }}'
       login_port: '{{ mongodb__conf_net_port }}'
       name: '{{ mongodb__admin_user["username"] }}'
       password: '{{ mongodb__admin_user["password"] }}'
@@ -159,7 +159,7 @@
 
   - name: 'Create, update or delete MongoDB users'
     community.mongodb.mongodb_user:
-      login_host: '{{ mongodb__conf_net_bind_ip }}'
+      login_host: '{{ mongodb__conf_net_bind_ip[0] }}'
       login_port: '{{ mongodb__conf_net_port }}'
       login_user: '{{ mongodb__admin_user["username"] }}'
       login_password: '{{ mongodb__admin_user["password"] }}'
@@ -187,7 +187,7 @@
 
   - name: 'Create MongoDB Dump user'
     community.mongodb.mongodb_user:
-      login_host: '{{ mongodb__conf_net_bind_ip }}'
+      login_host: '{{ mongodb__conf_net_bind_ip[0] }}'
       login_port: '{{ mongodb__conf_net_port }}'
       login_user: '{{ mongodb__admin_user["username"] }}'
       login_password: '{{ mongodb__admin_user["password"] }}'

--- a/roles/mongodb/templates/etc/Debian-6.0-mongod.conf.j2
+++ b/roles/mongodb/templates/etc/Debian-6.0-mongod.conf.j2
@@ -28,7 +28,7 @@ systemLog:
 # network interfaces
 net:
   port: {{ mongodb__conf_net_port }}
-  bindIp: {{ mongodb__conf_net_bind_ip }}
+  bindIp: {{ mongodb__conf_net_bind_ip | join(",") }}
 
 # how the process runs
 processManagement:

--- a/roles/mongodb/templates/etc/RedHat-4.2-mongod.conf.j2
+++ b/roles/mongodb/templates/etc/RedHat-4.2-mongod.conf.j2
@@ -34,7 +34,7 @@ processManagement:
 # network interfaces
 net:
   port: {{ mongodb__conf_net_port }}
-  bindIp: {{ mongodb__conf_net_bind_ip }}
+  bindIp: {{ mongodb__conf_net_bind_ip | join(",") }}
 
 security:
   authorization: {{ mongodb__conf_security_authorization | ternary('enabled', 'disabled') }}

--- a/roles/mongodb/templates/etc/RedHat-4.4-mongod.conf.j2
+++ b/roles/mongodb/templates/etc/RedHat-4.4-mongod.conf.j2
@@ -32,7 +32,7 @@ processManagement:
 # network interfaces
 net:
   port: {{ mongodb__conf_net_port }}
-  bindIp: {{ mongodb__conf_net_bind_ip }}
+  bindIp: {{ mongodb__conf_net_bind_ip | join(",") }}
 
 security:
   authorization: {{ mongodb__conf_security_authorization | ternary('enabled', 'disabled') }}

--- a/roles/mongodb/templates/etc/RedHat-5.0-mongod.conf.j2
+++ b/roles/mongodb/templates/etc/RedHat-5.0-mongod.conf.j2
@@ -32,7 +32,7 @@ processManagement:
 # network interfaces
 net:
   port: {{ mongodb__conf_net_port }}
-  bindIp: {{ mongodb__conf_net_bind_ip }}
+  bindIp: {{ mongodb__conf_net_bind_ip | join(",") }}
 
 security:
   authorization: {{ mongodb__conf_security_authorization | ternary('enabled', 'disabled') }}

--- a/roles/mongodb/templates/etc/RedHat-6.0-mongod.conf.j2
+++ b/roles/mongodb/templates/etc/RedHat-6.0-mongod.conf.j2
@@ -32,7 +32,7 @@ processManagement:
 # network interfaces
 net:
   port: {{ mongodb__conf_net_port }}
-  bindIp: {{ mongodb__conf_net_bind_ip }}
+  bindIp: {{ mongodb__conf_net_bind_ip | join(",") }}
 
 security:
   authorization: {{ mongodb__conf_security_authorization | ternary('enabled', 'disabled') }}


### PR DESCRIPTION
Fix connection issue when multiple address in `mongodb__conf_net_bind_ip` where specified.
As example `mongodb__conf_net_bind_ip: 'localhost,10.122.10.20` 

```
TASK [linuxfabrik.lfops.mongodb : Create DBA "ansible" (if first user, using localhost exception)] ***
fatal: [p-vm-facts-001.stadtluzern.ch]: FAILED! => {"changed": false, "msg": "Unable to connect to database: Cannot specify multiple hosts with directConnection=true"}
```