### PR TITLE
role:opensearch:bugfix internal user hash

### DIFF
--- a/roles/opensearch/templates/etc/opensearch/opensearch-security/internal_users.yml.j2
+++ b/roles/opensearch/templates/etc/opensearch/opensearch-security/internal_users.yml.j2
@@ -13,7 +13,7 @@ _meta:
 
 {% for user in opensearch__internal_users__hashed_result["results"] if user["item"]['state'] | d('present') != 'absent' %}
 {{ user["item"]["username"] }}:
-  hash: '{{ user["stdout"] }}'
+  hash: '{{ user["stdout"].splitlines() | last }}'
   backend_roles: {{ user["item"]["backend_roles"] | d([]) }}
   # prevent changes via API as it is managed by ansible
   # https://opensearch.org/docs/latest/security/access-control/api/#reserved-and-hidden-resources


### PR DESCRIPTION
In version 2.5.0 of OpenSearch, the hash.sh file prints a deprication-warning message before printing the hash:
```
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
$2y$12$WIHjdYc918U.JspWjwnXZO1euq2ROrgSaRMmVbHPgVqnqj2Zt2GuO
```
Ansible will therefore print the full string into `internal_users.yml` file, resulting in the following misbehavior:
```
# Define your internal users here

opensearch-admin:
  hash: '**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
$2y$12$WIHjdYc918U.JspWjwnXZO1euq2ROrgSaRMmVbHPgVqnqj2Zt2GuO'
  backend_roles: ['admin']
  # prevent changes via API as it is managed by ansible
  # https://opensearch.org/docs/latest/security/access-control/api/#reserved-and-hidden-resources
  reserved: true
```

**Note:** This issue has been fixed in OpenSearch version 2.11.0 (https://github.com/opensearch-project/security/pull/3454)
