### PR TITLE
role:repo_graylog: repo uses local pgp key

### DIFF
--- a/roles/repo_graylog/tasks/Debian.yml
+++ b/roles/repo_graylog/tasks/Debian.yml
@@ -27,6 +27,11 @@
       file: '/tmp/tmp/ansible.graylog.pgp'
       state: 'present'
 
+  - name: 'rm /tmp/ansible.graylog.pgp'
+    ansible.builtin.file:
+      path: '/tmp/tmp/ansible.graylog.pgp'
+      state: 'absent'
+
   - name: 'deploy the repo file (mirror: {{ repo_graylog__mirror_url | default("") }})'
     ansible.builtin.template:
       src: 'etc/apt/sources.list.d/graylog.list.j2'

--- a/roles/repo_graylog/tasks/Debian.yml
+++ b/roles/repo_graylog/tasks/Debian.yml
@@ -22,14 +22,14 @@
       dest: '/tmp/ansible.graylog.gpg'
       mode: 0o644
 
-  - name: 'apt-key add /tmp/ansible.graylog.pgp'
+  - name: 'apt-key add /tmp/ansible.graylog.gpg'
     ansible.builtin.apt_key:
-      file: '/tmp/tmp/ansible.graylog.pgp'
+      file: '/tmp/ansible.graylog.gpg'
       state: 'present'
 
-  - name: 'rm /tmp/ansible.graylog.pgp'
+  - name: 'rm /tmp/ansible.graylog.gpg'
     ansible.builtin.file:
-      path: '/tmp/tmp/ansible.graylog.pgp'
+      path: '/tmp/ansible.graylog.gpg'
       state: 'absent'
 
   - name: 'deploy the repo file (mirror: {{ repo_graylog__mirror_url | default("") }})'

--- a/roles/repo_graylog/tasks/Debian.yml
+++ b/roles/repo_graylog/tasks/Debian.yml
@@ -7,9 +7,24 @@
         - 'gnupg'
       state: 'present'
 
-  - name: 'wget -qO - https://packages.graylog2.org/repo/debian/pubkey.gpg | apt-key add -'
-    ansible.builtin.apt_key:
+  - name: 'curl https://packages.graylog2.org/repo/debian/pubkey.gpg --output /tmp/ansible.graylog.gpg'
+    ansible.builtin.get_url:
       url: 'https://packages.graylog2.org/repo/debian/pubkey.gpg'
+      dest: '/tmp/ansible.graylog.gpg'
+      mode: 0o644
+    delegate_to: 'localhost'
+    changed_when: false # not an actual config change on the server
+    check_mode: false # run task even if `--check` is specified
+
+  - name: 'copy /tmp/ansible.graylog.gpg to remote host'
+    ansible.builtin.copy:
+      src: '/tmp/ansible.graylog.gpg'
+      dest: '/tmp/ansible.graylog.gpg'
+      mode: 0o644
+
+  - name: 'apt-key add /tmp/ansible.graylog.pgp'
+    ansible.builtin.apt_key:
+      file: '/tmp/tmp/ansible.graylog.pgp'
       state: 'present'
 
   - name: 'deploy the repo file (mirror: {{ repo_graylog__mirror_url | default("") }})'

--- a/roles/repo_graylog/tasks/RedHat.yml
+++ b/roles/repo_graylog/tasks/RedHat.yml
@@ -1,17 +1,17 @@
 - block:
-  - name: 'curl https://packages.graylog2.org/repo/debian/pubkey.gpg --output /tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg'
+  - name: 'curl https://packages.graylog2.org/repo/debian/pubkey.gpg --output /tmp/ansible.RPM-GPG-KEY-graylog'
     ansible.builtin.get_url:
       url: 'https://packages.graylog2.org/repo/debian/pubkey.gpg'
-      dest: '/tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg'
+      dest: '/tmp/ansible.RPM-GPG-KEY-graylog'
       mode: 0o644
     delegate_to: 'localhost'
     changed_when: false # not an actual config change on the server
     check_mode: false # run task even if `--check` is specified
 
-  - name: 'copy /tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg to remote host'
+  - name: 'copy /tmp/ansible.RPM-GPG-KEY-graylog to remote host'
     ansible.builtin.copy:
-      src: '/tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg'
-      dest: '/etc/pki/rpm-gpg/RPM-GPG-KEY-GRAYLOG.gpg'
+      src: '/tmp/ansible.RPM-GPG-KEY-graylog'
+      dest: '/etc/pki/rpm-gpg/RPM-GPG-KEY-graylog'
       mode: 0o644
 
   # https://www.elastic.co/guide/en/graylog/reference/current/rpm.html#rpm-repo

--- a/roles/repo_graylog/tasks/RedHat.yml
+++ b/roles/repo_graylog/tasks/RedHat.yml
@@ -1,4 +1,18 @@
 - block:
+  - name: 'curl https://packages.graylog2.org/repo/debian/pubkey.gpg --output /tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg'
+    ansible.builtin.get_url:
+      url: 'https://packages.graylog2.org/repo/debian/pubkey.gpg'
+      dest: '/tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg'
+      mode: 0o644
+    delegate_to: 'localhost'
+    changed_when: false # not an actual config change on the server
+    check_mode: false # run task even if `--check` is specified
+
+  - name: 'copy /tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg to remote host'
+    ansible.builtin.copy:
+      src: '/tmp/ansible.RPM-GPG-KEY-GRAYLOG.gpg'
+      dest: '/etc/pki/rpm-gpg/RPM-GPG-KEY-GRAYLOG.gpg'
+      mode: 0o644
 
   # https://www.elastic.co/guide/en/graylog/reference/current/rpm.html#rpm-repo
   - name: 'Deploy the graylog repo (mirror: {{ repo_graylog__mirror_url }})'

--- a/roles/repo_graylog/templates/etc/yum.repos.d/graylog.repo.j2
+++ b/roles/repo_graylog/templates/etc/yum.repos.d/graylog.repo.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-# 2024032701
+# 2024050101
 
 # https://docs.graylog.org/docs/operating-system-packages
 [graylog-{{ repo_graylog__version }}]
@@ -12,7 +12,7 @@ baseurl=https://packages.graylog2.org/repo/el/stable/{{ repo_graylog__version }}
 gpgcheck=1
 repo_gpgcheck=0
 #gpgkey=https://raw.githubusercontent.com/Graylog2/fpm-recipes/{{ repo_graylog__version }}/recipes/graylog-repository/files/rpm/RPM-GPG-KEY-graylog
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-GRAYLOG.gpg
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog
 {% if repo_graylog__basic_auth_login is defined and repo_graylog__basic_auth_login | length %}
 username={{ repo_graylog__basic_auth_login["username"] }}
 password={{ repo_graylog__basic_auth_login["password"] }}

--- a/roles/repo_graylog/templates/etc/yum.repos.d/graylog.repo.j2
+++ b/roles/repo_graylog/templates/etc/yum.repos.d/graylog.repo.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-# 2023122901
+# 2024032701
 
 # https://docs.graylog.org/docs/operating-system-packages
 [graylog-{{ repo_graylog__version }}]
@@ -11,7 +11,8 @@ baseurl=https://packages.graylog2.org/repo/el/stable/{{ repo_graylog__version }}
 {% endif %}
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://raw.githubusercontent.com/Graylog2/fpm-recipes/{{ repo_graylog__version }}/recipes/graylog-repository/files/rpm/RPM-GPG-KEY-graylog
+#gpgkey=https://raw.githubusercontent.com/Graylog2/fpm-recipes/{{ repo_graylog__version }}/recipes/graylog-repository/files/rpm/RPM-GPG-KEY-graylog
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-GRAYLOG.gpg
 {% if repo_graylog__basic_auth_login is defined and repo_graylog__basic_auth_login | length %}
 username={{ repo_graylog__basic_auth_login["username"] }}
 password={{ repo_graylog__basic_auth_login["password"] }}


### PR DESCRIPTION
Changed repo so that it will download gpg-key first on localhost (just like https://github.com/Linuxfabrik/lfops/commit/83d45db09a332731785ff277a7d50fe5596a52b8)
**Only testen on RedHat, not Debian**