### PR TITLE
AWX requires proper dependencies

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -50,7 +50,8 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  - ansible.utils
 
 # The URL of the originating SCM repository
 repository: 'https://github.com/linuxfabrik/lfops'


### PR DESCRIPTION
Add ansbile.utils to dependencies to fix "Could not load \"ansible.utils.ipv4\": 'Invalid plugin FQCN (ansible.utils.ipv4): unable to locate collection ansible.utils'" while running icinga2_agent role on AWX.