### PR TITLE
fix(roles/mariadb-server): update deprecated param

### DIFF
--- a/roles/mariadb_server/templates/usr/local/bin/mariadb-dump.j2
+++ b/roles/mariadb_server/templates/usr/local/bin/mariadb-dump.j2
@@ -5,8 +5,8 @@
 #          https://www.linuxfabrik.ch/
 # License: The Unlicense, see LICENSE file.
 
-# This file is managed by Ansible - do not edit
-# 2025092401
+# {{ ansible_managed }}
+# 2026022701
 
 
 # no `set -e` because we change some things at the beginning of the script
@@ -70,7 +70,7 @@ mydumper_params+="--routines "
 mydumper_params+="--threads=$THREADS "
 mydumper_params+="--triggers "
 mydumper_params+="--trx-tables=0 "
-mydumper_params+="--verbose 3 "
+mydumper_params+="--verbose=3 "
 mydumper_params+="$RAW "
 
 # run mydumper


### PR DESCRIPTION
--trx-tables is enabled by default since 2026-05-18 but since mydumper v0.20.2-1 no-trx-tables replaces trx-tables=0; commit hash is 38d300e8