### PR TITLE
feat(roles/nfs_server): Rework `nfs_server__exports`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+* **role:nfs_server**: Rework `nfs_server__exports` from a list of strings to a list of dictionaries with new `path`, `clients`, `owner`, `group`, and `mode` subkeys
 * **role:kvm_host**: Change NAT to be explicitly activated for virtual nets
 * **role:apache_httpd**: Change the default to not install/enable mod_qos by default (it is no longer shipped in EPEL 10)
 

--- a/roles/nfs_server/README.md
+++ b/roles/nfs_server/README.md
@@ -7,23 +7,31 @@ This role installs and configures [NFS](http://linux-nfs.org/) as a server.
 
 | Tag                  | What it does                           | Reload / Restart |
 | ---                  | ------------                           | ---------------- |
-| `nfs_server`         | Installs and configures NFS  as server | Reloads nfs-server.service |
-| `nfs_server:state`   | Manages the state of the NFS server    | - |
-| `nfs_server:exports` | Configures the NFS exports             | Reloads nfs-server.service |
+| `nfs_server`         | <ul><li>Install nfs-utils on RedHat-Based systems or nfs-kernel-server on Debian-Based systems</li><li>Enable/disable nfs-server.service</li><li>`mkdir -p nfs-export-directory`</li><li>Deploy /etc/exports</li></ul> | Reloads nfs-server.service |
+| `nfs_server:state`   | <ul><li>Enable/disable nfs-server.service</li></ul> | - |
+| `nfs_server:exports` | <ul><li>`mkdir -p nfs-export-directory`</li><li>Deploy /etc/exports</li></ul> | Reloads nfs-server.service |
 
 
 ## Mandatory Role Variables
 
-| Variable              | Description                                                         |
-| --------              | -----------                                                         |
-| `nfs_server__exports` | A list of valid NFS server exports. Have a look at `man 5 exports`. |
+| Variable | Description |
+| -------- | ----------- |
+| `nfs_server__exports` | List of NFS exports to create. Subkeys: <ul><li>`path`: Mandatory, string. Directory to export.</li><li>`clients`: Mandatory, list. List of client specifications. Have a look at `man 5 exports`.</li><li>`owner`: Optional, string. Owner of the export directory. Defaults to `'nobody'`.</li><li>`group`: Optional, string. Group of the export directory. Defaults to `'nogroup'` (`'nobody'` for RHEL, CentOS, Fedora, Rocky).</li><li>`mode`: Optional, string. Mode of the export directory. Defaults to `'0o755'`.</li></ul> |
 
 Example:
 ```yaml
 # mandatory
 nfs_server__exports:
-  - '/data/appserver1 192.0.2.10(rw,sync,all_squash)'
-  - '/data/appserver2 192.0.2.11(ro,sync,all_squash)'
+  - path: '/data/dir1'
+    clients:
+      - '192.0.2.1(rw,sync,all_squash)'
+      - '192.0.2.2(ro,sync,all_squash)'
+    owner: 'root'
+    group: 'root'
+    mode: '0o755'
+  - path: '/data/dir2'
+    clients:
+      - '192.0.2.3(ro,sync,all_squash)'
 ```
 
 

--- a/roles/nfs_server/defaults/main.yml
+++ b/roles/nfs_server/defaults/main.yml
@@ -1,1 +1,3 @@
+nfs_server__group: '{{ "nobody" if ansible_os_family == "RedHat" else "nogroup" }}'
+nfs_server__owner: 'nobody'
 nfs_server__service_enabled: true

--- a/roles/nfs_server/tasks/main.yml
+++ b/roles/nfs_server/tasks/main.yml
@@ -6,6 +6,7 @@
     - 'always'
     - 'nfs_server'  # for --skip-tags
 
+
 - block:
 
   - name: 'Install {{ nfs_server__nfs_server_package }}'
@@ -15,6 +16,7 @@
 
   tags:
     - 'nfs_server'
+
 
 - block:
 
@@ -31,12 +33,13 @@
 
 - block:
 
-  - name: 'Ensure directories to export exist'
+  - name: 'mkdir -p nfs-export-directory'
     ansible.builtin.file:
-      path: '{{ item.strip().split()[0] }}'
+      path: '{{ item["path"] }}'
       state: 'directory'
-      owner: '{{ nfs_server__owner }}'
-      group: '{{ nfs_server__group }}'
+      owner: '{{ item["owner"] | default(nfs_server__owner) }}'
+      group: '{{ item["group"] | default(nfs_server__group) }}'
+      mode: '{{ item["mode"] | default("0o755") }}'
     loop: '{{ nfs_server__exports }}'
 
   - name: 'Deploy /etc/exports'

--- a/roles/nfs_server/templates/etc/exports.j2
+++ b/roles/nfs_server/templates/etc/exports.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
-# 2022072201
+# 2026031801
 
 {% for item in nfs_server__exports %}
-{{ item }}
+{{ item['path'] }} {{ item['clients'] | join(' ') }}
 {% endfor %}

--- a/roles/nfs_server/vars/Debian.yml
+++ b/roles/nfs_server/vars/Debian.yml
@@ -1,3 +1,1 @@
-nfs_server__group: 'nogroup'
 nfs_server__nfs_server_package: 'nfs-kernel-server'
-nfs_server__owner: 'nobody'

--- a/roles/nfs_server/vars/RedHat.yml
+++ b/roles/nfs_server/vars/RedHat.yml
@@ -1,3 +1,1 @@
-nfs_server__group: 'nobody'
 nfs_server__nfs_server_package: 'nfs-utils'
-nfs_server__owner: 'nobody'


### PR DESCRIPTION
Rework `nfs_server__exports` from a list of raw strings to a list of dictionaries with new `path`, `clients`, `owner`, `group`, and `mode` subkeys