### PR TITLE
fix(roles/grafana): add homepath

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -173,7 +173,9 @@
     when: 'grafana__systemctl_result["changed"] | bool'
 
   - name: 'set the password for admin'
-    ansible.builtin.command: "grafana-cli admin reset-admin-password '{{ grafana__admin_login[\"password\"] }}'"
+    ansible.builtin.command: "grafana cli admin reset-admin-password '{{ grafana__admin_login[\"password\"] }}'"
+    args:
+      chdir: '/usr/share/grafana' # fixes: Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath
 
   tags:
     - 'grafana'


### PR DESCRIPTION
Fixes:
 `Use the 'grafana cli' subcommand instead.", "stderr_lines": ["Deprecation warning: 'grafana-cli' is deprecated and will be removed in a future release. Use the 'grafana cli' subcommand instead."], "stdout": "Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath", "stdout_lines": ["Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath"]}`