### PR TITLE
Add plugin unit-test infrastructure + combine_lod fixes

### DIFF
--- a/.github/workflows/lf-unit-tests.yml
+++ b/.github/workflows/lf-unit-tests.yml
@@ -1,0 +1,48 @@
+name: 'Linuxfabrik: Unit Tests'
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+permissions:
+  contents: 'read'
+
+jobs:
+  controller-plugins:
+    name: 'Controller plugins (Python ${{ matrix.python-version }})'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        # Controller-side plugins (filter, lookup). The managed-node tier
+        # (modules on RHEL 8 / Python 3.6) needs a UBI 8 container and is
+        # scaffolded in tox.ini, not run here yet.
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+    steps:
+      - name: 'Harden the runner (Audit all outbound calls)'
+        uses: 'step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411' # v2.19.4
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+
+      - name: 'Set up Python'
+        uses: 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405' # v6.2.0
+        with:
+          python-version: '${{ matrix.python-version }}'
+
+      - name: 'Install tox'
+        run: 'pip install tox'
+
+      - name: 'Run tox for this Python (all matching ansible-core envs)'
+        # `-f pyXYZ` selects every tox env carrying this Python's factor,
+        # e.g. py311 -> py311-ansible215/216/217/218.
+        run: 'tox -f py$(echo "${{ matrix.python-version }}" | tr -d ".")'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,17 @@ repos:
       - id: 'vulture'
         args: ['--min-confidence=80']
         types_or: ['python']
+
+  - repo: 'local'
+    hooks:
+      - id: 'pytest-unit'
+        name: 'pytest (plugin unit tests)'
+        # Fast single-interpreter run of the controller-plugin unit tests on
+        # every commit. The full Python x ansible-core matrix runs in CI via
+        # tox; see tests/README.md.
+        entry: 'pytest tests/unit'
+        language: 'python'
+        additional_dependencies: ['ansible-core', 'pytest', 'pyyaml']
+        pass_filenames: false
+        files: '^(plugins/|tests/unit/)'
+        types_or: ['python']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **plugin:combine_lod**: The `combine_lod` filter now reports an error when an item is missing part of a composite `unique_key` (a list of keys), instead of silently grouping such items together. Inventories with incomplete composite keys that previously merged by accident now fail loudly and must be corrected. Also fixed its documentation so `ansible-doc` renders it again.
 * **role:kernel_settings**: The `systemd_cpu_affinity` setting is now actually applied. The value was computed and shown in the debug output but never passed to the underlying system role, so a configured CPU affinity had no effect.
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -754,6 +754,37 @@ Some files under `plugins/modules/` are not authored by Linuxfabrik but vendored
     * Drop when: LFOps raises its minimum ansible-core to >= 2.18; switch to `community.general.lvm_pv` and update `roles/lvm` accordingly.
 
 
+### Plugins
+
+In-house plugins live under `plugins/` following the standard Ansible collection layout: `filter/`, `lookup/`, `modules/` and `module_utils/`. The `## Tasks` rules above (FQCN, meta modules, idempotency) are about role tasks; the points below are specific to writing the plugins themselves.
+
+* Every plugin carries `DOCUMENTATION` (and `RETURN` / `EXAMPLES` where applicable). Keep it valid YAML: in a `description` list, a bullet containing a colon followed by a space is parsed as a mapping and makes `ansible-doc` fail, so rephrase or quote such bullets. Verify with `ansible-doc -t <filter|lookup|module> linuxfabrik.lfops.<name>`.
+* Set `version_added` to the LFOps release the plugin first shipped in, and never change it afterwards.
+* `module_utils` holds code shared between plugins. Do not import the external Linuxfabrik Python Libraries (`lib`) into a plugin; copy what you need and note the origin in a comment.
+
+
+#### Plugin Tests
+
+Unit tests are **mandatory** for every in-house plugin. Any pull request that adds or changes a plugin must add or update its test, and `git grep` should never find a plugin without one.
+
+* **Where**: under `tests/unit/`, mirroring the plugin tree, named `test_<plugin>.py` (e.g. `tests/unit/plugins/filter/test_combine_lod.py`). Load the plugin by path (the plugins are not an importable package) and assert behavior, not implementation details.
+* **Two tiers**, because plugins run in different environments:
+
+    * Controller plugins (`plugins/filter/`, `plugins/lookup/`) are evaluated on the Ansible controller and only ever see the controller's Python (>= 3.10). They run on the standard CI matrix.
+    * Managed-node plugins (`plugins/modules/`, `plugins/module_utils/`) are executed on the target host and must keep working down to the oldest managed-node Python we maintain (Python 3.6 on RHEL 8). That tier runs inside a RHEL 8 / UBI 8 container; it is scaffolded in `tox.ini` (`[testenv:py36-target]`) and gets enabled once such tests exist.
+
+* **How to run / verify** (the matrix of Python and ansible-core versions is driven by `tox`; see `tests/README.md` and `tox.ini`):
+
+    ```bash
+    tox                      # full controller matrix (every Python x ansible-core combination)
+    tox -e py311-ansible216  # a single combination
+    tox -f py311             # every ansible-core for one Python
+    pytest tests/unit        # against the active interpreter (needs pytest, pyyaml, ansible-core)
+    ```
+
+* The `Linuxfabrik: Unit Tests` workflow runs the controller matrix on every push and pull request.
+
+
 ### Credits
 
 * <https://github.com/whitecloud/ansible-styleguide>

--- a/plugins/filter/combine_lod.py
+++ b/plugins/filter/combine_lod.py
@@ -1,10 +1,13 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
-# Copyright: (c) 2022, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
-
-# Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 import collections
@@ -18,9 +21,11 @@ DOCUMENTATION = r'''
   description:
     - Merges one or more lists of dictionaries into a single list. Dictionaries that share the same value under I(unique_key) are folded into one entry; later entries overwrite earlier ones (non-recursive, like Python C(dict.update)).
     - The folding also collapses duplicates inside a single input list, so passing one list with duplicates is a valid way to deduplicate it.
-    - Useful for layering inventory: a role can ship sensible defaults, and the user can selectively override individual keys per item from their inventory without having to redeclare the whole list.
+    - Useful for layering inventory. A role can ship sensible defaults, and the user can selectively override individual keys per item from their inventory without having to redeclare the whole list.
     - Sub-dictionaries and sub-lists are replaced wholesale, not merged recursively. To merge nested structures, build the nested values up using this filter at each level.
-    - Every input dictionary must contain the unique key (or all keys, if a list is passed). A missing or falsy key value (C(None), C(0), empty string) raises an error.
+    - The result keeps the order in which each unique key is first seen across all input lists; later updates to an existing key do not move it.
+    - Every list item must be a dictionary; a non-dictionary item raises an error.
+    - Every input dictionary must contain the unique key (or all of them, when a list of keys is passed). A missing or falsy key value (C(None), C(0), empty string) raises an error.
   positional: _input, _dicts
   options:
     _input:
@@ -50,7 +55,7 @@ EXAMPLES = r'''
         first_value: 'sensible default for first value'
         second_value: 'sensible default for second value'
       - name: 'setting 2'
-        allow_all: False
+        allow_all: false
         allowed_users:
           - 'root'
 
@@ -67,8 +72,7 @@ EXAMPLES = r'''
   debug:
     msg: '{{ role_defaults | linuxfabrik.lfops.combine_lod(my_user_adjustments) }}'
 
-# =>
-# (reordered for readability)
+# => (keys keep their first-seen order)
 # - name: setting 1
 #   first_value: better setting for me
 #   second_value: sensible default for second value
@@ -76,6 +80,24 @@ EXAMPLES = r'''
 #   allow_all: false
 #   allowed_users:
 #   - linuxfabrik
+
+
+# composite unique_key: the same server_name on different ports stays separate
+- name: 'merge vhosts by name + port'
+  debug:
+    msg: >-
+      {{ [{'server_name': 'example.com', 'server_port': 80, 'root': '/var/www'},
+          {'server_name': 'example.com', 'server_port': 443, 'root': '/var/www'}]
+         | linuxfabrik.lfops.combine_lod([{'server_name': 'example.com', 'server_port': 443, 'root': '/srv/tls'}],
+                                         unique_key=['server_name', 'server_port']) }}
+
+# =>
+# - server_name: example.com
+#   server_port: 80
+#   root: /var/www
+# - server_name: example.com
+#   server_port: 443
+#   root: /srv/tls
 
 
 # more complicated example
@@ -161,15 +183,26 @@ def combine_lod(*args, **kwargs):
     for lod in list(args):
         for item in lod:
             if not isinstance(item, collections.abc.MutableMapping):
-                raise AnsibleFilterError("found non-dictionary item in the list, this is not supported")
+                raise AnsibleFilterError('found a non-dictionary item in the list, this is not supported')
 
             if isinstance(unique_key, collections.abc.MutableSequence):
-                key = tuple(item.get(k, None) for k in unique_key)
+                key_components = [item.get(k, None) for k in unique_key]
+                # a tuple is always truthy, even `(None, None)`, so the `not key`
+                # check used for single keys would not catch a composite key with
+                # missing components. Validate each component explicitly instead.
+                if not all(key_components):
+                    raise AnsibleFilterError(
+                        f'found a dictionary missing one of the unique keys {unique_key}, '
+                        'this is not supported'
+                    )
+                key = tuple(key_components)
             else:
                 key = item.get(unique_key, None)
-
-            if not key:
-                raise AnsibleFilterError("found an dictionary without the unique key, this is not supported")
+                if not key:
+                    raise AnsibleFilterError(
+                        f"found a dictionary without the unique key '{unique_key}', "
+                        'this is not supported'
+                    )
 
             # the python dict.update function does exactly what we want.
             # it is also used for ansible.builtin.combine(..., recurse=False, list_merge='replace').
@@ -186,328 +219,3 @@ class FilterModule(object):
         return {
             'combine_lod': combine_lod,
         }
-
-
-
-if __name__ == '__main__':
-    import textwrap
-    import unittest
-
-    import yaml
-
-    class Test(unittest.TestCase):
-
-        def test_combine_lod_non_dict_item(self):
-            '''
-            non-dictionaries list elements are not supported
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'test1'
-            - 'im a string'
-            '''))
-
-            with self.assertRaises(AnsibleFilterError):
-                combine_lod(input1)
-
-
-        def test_combine_lod_last(self):
-            '''
-            the last element should always win and overwrite the earlier ones
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'test1'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'test2'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'test2'
-            '''))
-
-            result = combine_lod(input1, input2)
-
-            # print('input1:')
-            # print(yaml.dump(input1, default_flow_style=False))
-            # print('input2:')
-            # print(yaml.dump(input2, default_flow_style=False))
-            # print('result:')
-            # print(yaml.dump(result, default_flow_style=False))
-            # print('expected:')
-            # print(yaml.dump(expected, default_flow_style=False))
-
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_multiple(self):
-            '''
-            test the basic functionality if there are multiple list elements
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'first variable'
-              value: 'test1'
-            - name: 'second variable'
-              value: 'test2'
-            - name: 'other_var'
-              value: 'linuxfabrik'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - name: 'first variable'
-              value: 'test1 - edited'
-            - name: 'second variable'
-              value: 'test2 - edited'
-              new_value: 'new here'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'first variable'
-              value: 'test1'
-              value: 'test1 - edited'
-            - name: 'second variable'
-              value: 'test2 - edited'
-              new_value: 'new here'
-            - name: 'other_var'
-              value: 'linuxfabrik'
-            '''))
-
-            result = combine_lod(input1, input2)
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_single_input(self):
-            '''
-            test if everything works if the lists are already combined beforehand
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'test1'
-            - name: 'myvar'
-              value: 'test2'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'test2'
-            '''))
-
-            result = combine_lod(input1)
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_replace_given_keys(self):
-            '''
-            only the given keys are overwritten, not the whole list element
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 1'
-              my_list:
-                - 'input1'
-                - 'lots of default entries'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 2'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 2'
-              my_list:
-                - 'input1'
-                - 'lots of default entries'
-            '''))
-
-            result = combine_lod(input1, input2)
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_different_single_unique_key(self):
-            '''
-            test if using a different single unique_key works
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - filename: 'myvar 1'
-              value: 'value 1'
-            - filename: 'myvar 2'
-              value: 'value 1'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - filename: 'myvar 1'
-              value: 'value 1 - edited'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - filename: 'myvar 1'
-              value: 'value 1 - edited'
-            - filename: 'myvar 2'
-              value: 'value 1'
-            '''))
-
-            result = combine_lod(input1, input2, unique_key="filename")
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_different_list_unique_key(self):
-            '''
-            test if using a a list of unique_keys works
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - server_name: 'myvar'
-              server_port: 80
-              value: 'value 80'
-            - server_name: 'myvar'
-              server_port: 443
-              value: 'value 443'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - server_name: 'myvar'
-              server_port: 80
-              value: 'value 81'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - server_name: 'myvar'
-              server_port: 80
-              value: 'value 81'
-            - server_name: 'myvar'
-              server_port: 443
-              value: 'value 443'
-            '''))
-
-            result = combine_lod(input1, input2, unique_key=["server_name", "server_port"])
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_missing_unique_key(self):
-            '''
-            the plugin should throw an error if it cannot find the unique_key for all list elements
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 1'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - wrong_name: 'myvar'
-              value: 'value 1'
-            '''))
-
-            with self.assertRaises(AnsibleFilterError):
-                combine_lod(input1, input2)
-
-
-        def test_combine_lod_list_merge(self):
-            '''
-            if one of the keys in the dictionaries contains a list,
-            the list should just replace the previous lists.
-            no append / prepend of the list elements
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              my_list:
-                - 'input1'
-                - 'input_repeated'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              my_list:
-                - 'input2'
-                - 'input_repeated'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              my_list:
-                - 'input2'
-                - 'input_repeated'
-            '''))
-
-            result = combine_lod(input1, input2)
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_no_recursion(self):
-            '''
-            the plugin should not recurse into dicts or lists
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 1'
-              my_list:
-                - 'input1'
-                - name: 'my sub var'
-                  value: 'sub value 1'
-                - 'input_repeated'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 2'
-              my_dict:
-                name: 'my sub var'
-                value: 'sub value 1'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 2'
-              my_list:
-                - 'input1'
-                - name: 'my sub var'
-                  value: 'sub value 1'
-                - 'input_repeated'
-              my_dict:
-                name: 'my sub var'
-                value: 'sub value 1'
-            '''))
-
-            result = combine_lod(input1, input2)
-            self.assertEqual(result, expected)
-
-
-        def test_combine_lod_no_modification(self):
-            '''
-            in this case the plugin should not modify anything
-            '''
-
-            input1 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 1'
-            '''))
-
-            input2 = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 1'
-            '''))
-
-            expected = yaml.safe_load(textwrap.dedent('''
-            - name: 'myvar'
-              value: 'value 1'
-            '''))
-
-            result = combine_lod(input1, input2)
-            self.assertEqual(result, expected)
-
-
-    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,8 @@
 # real issues are fixed.
 paths = ["plugins", ".vulture_whitelist.py"]
 min_confidence = 80
+
+[tool.pytest.ini_options]
+# Unit tests for the in-house plugins. The matrix of Python / ansible-core
+# versions is driven by tox; see tox.ini.
+testpaths = ["tests/unit"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,57 @@
+# Tests
+
+Unit tests for the in-house LFOps plugins under `plugins/`.
+
+## Two tiers
+
+LFOps plugins run in two different environments, so they are tested differently:
+
+| Tier | Plugins | Runs on | Python / ansible-core |
+|---|---|---|---|
+| Controller | `plugins/filter/`, `plugins/lookup/` | Ansible controller | Python >= 3.10, ansible-core 2.15 - latest |
+| Managed node | `plugins/modules/`, `plugins/module_utils/` | target host | down to Python 3.6 (RHEL 8) |
+
+Filter and lookup plugins are evaluated on the controller during templating, so they only ever see the controller's Python. Modules and module utils are shipped to and executed on the managed node, which on RHEL 8 still uses the system Python 3.6.
+
+## Layout
+
+Tests mirror the plugin tree:
+
+```
+tests/unit/plugins/filter/test_<name>.py
+tests/unit/plugins/lookup/test_<name>.py
+tests/unit/plugins/modules/test_<name>.py        # managed-node tier
+tests/unit/plugins/module_utils/test_<name>.py   # managed-node tier
+```
+
+Each test loads its plugin by path (the plugins are not an importable package) and may import `ansible.errors` / `ansible.module_utils`, so ansible-core must be installed in the test environment.
+
+## Running
+
+Run the controller matrix (Python x ansible-core combinations) with tox:
+
+```bash
+tox
+```
+
+Run a single environment, or everything for one Python:
+
+```bash
+tox -e py311-ansible216
+tox -f py311
+```
+
+Run the tests directly against the active interpreter (needs `pytest`, `pyyaml` and `ansible-core`):
+
+```bash
+pytest tests/unit
+```
+
+## Managed-node tier (Python 3.6 / RHEL 8)
+
+CI runners no longer ship Python 3.6, so module tests have to run inside a RHEL 8 / UBI 8 container. The `[testenv:py36-target]` env in `tox.ini` is scaffolded for this but not yet enabled, since the only plugin with tests so far (`combine_lod`) is a controller-side filter. Enable it once module tests exist, for example:
+
+```bash
+podman run --rm -v "$PWD":/src:Z -w /src registry.access.redhat.com/ubi8/ubi \
+  bash -c 'dnf -y install python3 python3-pip && pip3 install tox && tox -e py36-target'
+```

--- a/tests/unit/plugins/filter/test_combine_lod.py
+++ b/tests/unit/plugins/filter/test_combine_lod.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
+
+"""Unit tests for the `combine_lod` filter plugin.
+
+`combine_lod` is a filter plugin and therefore runs on the Ansible
+controller only. The controller requires Python >= 3.10 (ansible-core
+2.16/2.17) or >= 3.11 (2.18), so this test runs on the controller
+matrix, not on the Python 3.6 (RHEL 8) managed-node tier. See
+`tests/README.md`.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import importlib.util
+import os
+import textwrap
+import unittest
+
+import yaml
+
+from ansible.errors import AnsibleFilterError
+
+# The plugin lives outside any importable package, so load it by path
+# (repo_root/plugins/filter/combine_lod.py) relative to this test file.
+_PLUGIN_PATH = os.path.join(
+    os.path.dirname(__file__),
+    '..', '..', '..', '..',
+    'plugins', 'filter', 'combine_lod.py',
+)
+_spec = importlib.util.spec_from_file_location('combine_lod', _PLUGIN_PATH)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+combine_lod = _module.combine_lod
+
+
+class Test(unittest.TestCase):
+
+    def test_combine_lod_non_dict_item(self):
+        """non-dictionary list elements are not supported"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'test1'
+        - 'im a string'
+        '''))
+
+        with self.assertRaises(AnsibleFilterError):
+            combine_lod(input1)
+
+    def test_combine_lod_last(self):
+        """the last element should always win and overwrite the earlier ones"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'test1'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'test2'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'test2'
+        '''))
+
+        result = combine_lod(input1, input2)
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_multiple(self):
+        """test the basic functionality if there are multiple list elements"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'first variable'
+          value: 'test1'
+        - name: 'second variable'
+          value: 'test2'
+        - name: 'other_var'
+          value: 'linuxfabrik'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - name: 'first variable'
+          value: 'test1 - edited'
+        - name: 'second variable'
+          value: 'test2 - edited'
+          new_value: 'new here'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'first variable'
+          value: 'test1 - edited'
+        - name: 'second variable'
+          value: 'test2 - edited'
+          new_value: 'new here'
+        - name: 'other_var'
+          value: 'linuxfabrik'
+        '''))
+
+        result = combine_lod(input1, input2)
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_single_input(self):
+        """test if everything works if the lists are already combined beforehand"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'test1'
+        - name: 'myvar'
+          value: 'test2'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'test2'
+        '''))
+
+        result = combine_lod(input1)
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_replace_given_keys(self):
+        """only the given keys are overwritten, not the whole list element"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 1'
+          my_list:
+            - 'input1'
+            - 'lots of default entries'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 2'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 2'
+          my_list:
+            - 'input1'
+            - 'lots of default entries'
+        '''))
+
+        result = combine_lod(input1, input2)
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_different_single_unique_key(self):
+        """test if using a different single unique_key works"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - filename: 'myvar 1'
+          value: 'value 1'
+        - filename: 'myvar 2'
+          value: 'value 1'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - filename: 'myvar 1'
+          value: 'value 1 - edited'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - filename: 'myvar 1'
+          value: 'value 1 - edited'
+        - filename: 'myvar 2'
+          value: 'value 1'
+        '''))
+
+        result = combine_lod(input1, input2, unique_key="filename")
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_different_list_unique_key(self):
+        """test if using a list of unique_keys works"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - server_name: 'myvar'
+          server_port: 80
+          value: 'value 80'
+        - server_name: 'myvar'
+          server_port: 443
+          value: 'value 443'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - server_name: 'myvar'
+          server_port: 80
+          value: 'value 81'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - server_name: 'myvar'
+          server_port: 80
+          value: 'value 81'
+        - server_name: 'myvar'
+          server_port: 443
+          value: 'value 443'
+        '''))
+
+        result = combine_lod(input1, input2, unique_key=["server_name", "server_port"])
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_missing_unique_key(self):
+        """the plugin should throw an error if it cannot find the unique_key for all list elements"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 1'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - wrong_name: 'myvar'
+          value: 'value 1'
+        '''))
+
+        with self.assertRaises(AnsibleFilterError):
+            combine_lod(input1, input2)
+
+    def test_combine_lod_composite_key_missing_component(self):
+        """a composite key with a missing component must raise, not silently group under None"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - server_name: 'myvar'
+          server_port: 80
+          value: 'value 80'
+        - server_name: 'myvar'
+          value: 'no port here'
+        '''))
+
+        with self.assertRaises(AnsibleFilterError):
+            combine_lod(input1, unique_key=["server_name", "server_port"])
+
+    def test_combine_lod_composite_key_all_components_missing(self):
+        """a composite key where every component is missing must raise as well"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - value: 'no keys at all'
+        '''))
+
+        with self.assertRaises(AnsibleFilterError):
+            combine_lod(input1, unique_key=["server_name", "server_port"])
+
+    def test_combine_lod_list_merge(self):
+        """a key holding a list should be replaced wholesale, no append / prepend"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          my_list:
+            - 'input1'
+            - 'input_repeated'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          my_list:
+            - 'input2'
+            - 'input_repeated'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          my_list:
+            - 'input2'
+            - 'input_repeated'
+        '''))
+
+        result = combine_lod(input1, input2)
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_no_recursion(self):
+        """the plugin should not recurse into dicts or lists"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 1'
+          my_list:
+            - 'input1'
+            - name: 'my sub var'
+              value: 'sub value 1'
+            - 'input_repeated'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 2'
+          my_dict:
+            name: 'my sub var'
+            value: 'sub value 1'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 2'
+          my_list:
+            - 'input1'
+            - name: 'my sub var'
+              value: 'sub value 1'
+            - 'input_repeated'
+          my_dict:
+            name: 'my sub var'
+            value: 'sub value 1'
+        '''))
+
+        result = combine_lod(input1, input2)
+        self.assertEqual(result, expected)
+
+    def test_combine_lod_no_modification(self):
+        """in this case the plugin should not modify anything"""
+
+        input1 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 1'
+        '''))
+
+        input2 = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 1'
+        '''))
+
+        expected = yaml.safe_load(textwrap.dedent('''
+        - name: 'myvar'
+          value: 'value 1'
+        '''))
+
+        result = combine_lod(input1, input2)
+        self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,63 @@
+# Test matrix for the in-house LFOps plugins.
+#
+# LFOps plugins fall into two tiers with different runtime environments:
+#
+#   * Controller plugins (filter, lookup) run on the Ansible controller.
+#     The controller requires Python >= 3.10 (ansible-core 2.16/2.17) or
+#     >= 3.11 (2.18). These are covered by the `py3XX-ansibleXYZ` envs
+#     below and run on standard CI runners via setup-python.
+#
+#   * Target plugins (modules, module_utils) run on the managed node and
+#     must therefore support the oldest managed-node Python we still
+#     maintain: Python 3.6 on RHEL 8. CI runners no longer ship Python
+#     3.6, so that tier has to run inside a RHEL 8 / UBI 8 container. It
+#     is scaffolded in `[testenv:py36-target]` below but not yet wired
+#     into CI, because the only plugin with tests so far (combine_lod) is
+#     a controller-side filter.
+#
+# ansible-core / controller-Python compatibility (see README.md):
+#   2.15: py3.9-3.11   2.16: py3.10-3.12   2.17: py3.10-3.12   2.18: py3.11-3.13
+# `requires_ansible` in meta/runtime.yml is `>=2.15.0`, so 2.15 is the floor.
+
+[tox]
+envlist =
+    py39-ansible215
+    py310-ansible{215,216,217}
+    py311-ansible{215,216,217,218}
+    py312-ansible{216,217,218}
+    py313-ansible{218,latest}
+skip_missing_interpreters = true
+# this collection is not a Python package, do not build an sdist from the repo root.
+no_package = true
+
+[testenv]
+description = 'Controller-plugin unit tests (filter, lookup)'
+deps =
+    pytest
+    pyyaml
+    ansible215: ansible-core~=2.15.0
+    ansible216: ansible-core~=2.16.0
+    ansible217: ansible-core~=2.17.0
+    ansible218: ansible-core~=2.18.0
+    ansiblelatest: ansible-core
+commands =
+    # discovers every controller-plugin test under tests/unit; managed-node
+    # plugin tests (modules) get their own env, see [testenv:py36-target].
+    pytest {posargs:tests/unit}
+
+# Scaffold for the managed-node tier (modules / module_utils). Not in the
+# default envlist. Run it inside a RHEL 8 / UBI 8 container where the system
+# Python is 3.6, against the matching ansible-core, e.g.:
+#
+#   podman run --rm -v "$PWD":/src:Z -w /src registry.access.redhat.com/ubi8/ubi \
+#     bash -c 'dnf -y install python3 python3-pip && pip3 install tox && tox -e py36-target'
+#
+# [testenv:py36-target]
+# description = 'Managed-node plugin unit tests (modules) on RHEL 8 Python 3.6'
+# basepython = python3.6
+# deps =
+#     pytest<7           # pytest 7+ dropped Python 3.6
+#     pyyaml
+#     ansible-core<2.12  # last series supporting a Python 3.6 runner
+# commands =
+#     pytest {posargs:tests/unit/plugins/modules tests/unit/plugins/module_utils}


### PR DESCRIPTION
First phase of the plugin unification/test effort. Establishes the test infrastructure and brings `combine_lod` (the reference plugin) up to standard. Vendored plugins (`ipa*`, `lvm_pv`, `module_utils/gnupg`) are out of scope and untouched.

## Test infrastructure

* **tox** matrix for the controller-side plugins: Python 3.9-3.13 × ansible-core 2.15/2.16/2.17/2.18 + latest (13 envs). `requires_ansible` floor is 2.15.
* **pytest** layout under `tests/unit/plugins/<type>/`, mirroring the plugin tree.
* **CI** workflow `Linuxfabrik: Unit Tests` runs the matrix on push/PR (Python matrix drives tox).
* **pre-commit** local hook runs `pytest tests/unit` on every commit that touches `plugins/` or `tests/unit/` (fast, single interpreter; full matrix stays in CI).
* **Two tiers** documented in `tests/README.md` and `CONTRIBUTING.md`: controller plugins (filter, lookup, Python >= 3.10) run on the matrix; managed-node plugins (modules, module_utils) must work down to Python 3.6 (RHEL 8) and get a UBI 8 container tier, scaffolded in `tox.ini` (`[testenv:py36-target]`).
* `CONTRIBUTING.md` now has a `Plugins` section and makes plugin unit tests **mandatory**.

## combine_lod

* **Fix**: a composite `unique_key` (list of keys) produced an always-truthy tuple, so an item missing one key was silently grouped under `(None, ...)` instead of raising. Each component is now validated explicitly.
* **Fix**: the DOCUMENTATION had a `description` bullet with a colon that YAML parsed as a mapping, breaking `ansible-doc` entirely (pre-existing on `main`). Now renders again.
* Adopt the standard Linuxfabrik file header, switch to f-strings, tighten the help text (deterministic output order, non-dict error, composite-key example).
* Move the embedded `__main__` tests into `tests/unit/plugins/filter/test_combine_lod.py` (13 tests, incl. new composite-key cases).

## Validation

* Full tox matrix green (13 envs, 13 tests each).
* `ansible-doc -t filter linuxfabrik.lfops.combine_lod` renders cleanly (was broken on `main`).
* pre-commit pytest hook verified end-to-end.

## Next phases (separate PRs)

bitwarden family, uptimerobot family, nextcloud/sqlite/gpg_key/ipa_diff: style unification + safe/security fixes + unit tests. Behavior-changing bugs (check_mode mutation, None-password overwrite, nextcloud array idempotency, get_item_by_id contract) are tracked separately, each with its own tested fix.