### PR TITLE
Unify uptimerobot plugin family + unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **plugin:uptimerobot_\***: The modules no longer crash when the UptimeRobot API returns a non-list response for a list endpoint; the response is passed through instead.
 * **plugin:nextcloud_occ_app_config, plugin:nextcloud_occ_system_config, plugin:uptimerobot_monitor, plugin:uptimerobot_psp**: Fixed their documentation so `ansible-doc` renders them again. A unit-test guard now catches this class of error for every in-house plugin.
 * **plugin:bitwarden_item**: Fixed the lookup's documentation so `ansible-doc` renders it again.
 * **plugin:combine_lod**: The `combine_lod` filter now reports an error when an item is missing part of a composite `unique_key` (a list of keys), instead of silently grouping such items together. Inventories with incomplete composite keys that previously merged by accident now fail loudly and must be corrected. Also fixed its documentation so `ansible-doc` renders it again.

--- a/plugins/module_utils/uptimerobot.py
+++ b/plugins/module_utils/uptimerobot.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 """Shared client for the UptimeRobot API used by the linuxfabrik.lfops.uptimerobot_*
 modules.
@@ -137,21 +139,21 @@ def resolve_api_key(module, api_key, api_key_file):
             with open(path) as fh:
                 value = fh.read().strip()
                 if value:
-                    module.log('uptimerobot: api_key resolved from file {0}'.format(path))
+                    module.log(f'uptimerobot: api_key resolved from file {path}')
                     return value
         except OSError:
             pass
 
     env = os.environ.get(ENV_API_KEY, '').strip()
     if env:
-        module.log('uptimerobot: api_key resolved from env {0}'.format(ENV_API_KEY))
+        module.log(f'uptimerobot: api_key resolved from env {ENV_API_KEY}')
         return env
 
     module.fail_json(msg=(
         'No UptimeRobot API key found. Provide one via the `api_key` parameter, '
-        'an `api_key_file` (default: {default}), or the {env} environment '
-        'variable.'
-    ).format(default=DEFAULT_API_KEY_FILE, env=ENV_API_KEY))
+        f'an `api_key_file` (default: {DEFAULT_API_KEY_FILE}), or the {ENV_API_KEY} '
+        'environment variable.'
+    ))
 
 
 # --- Wire format helpers -----------------------------------------------------
@@ -166,11 +168,9 @@ def alert_contacts_wire(items):
     """
     parts = []
     for item in items:
-        parts.append('{id}_{t}_{r}'.format(
-            id=item['id'],
-            t=item.get('threshold', 0),
-            r=item.get('recurrence', 0),
-        ))
+        parts.append(
+            f"{item['id']}_{item.get('threshold', 0)}_{item.get('recurrence', 0)}"
+        )
     return '-'.join(parts)
 
 
@@ -202,17 +202,15 @@ def _safe_keys(params):
     without leaking secrets to syslog.
     """
     return sorted(
-        '{0}=<redacted>'.format(k) if k in _SENSITIVE_KEYS else k
+        f'{k}=<redacted>' if k in _SENSITIVE_KEYS else k
         for k in params
     )
 
 
 def _cache_key(endpoint, api_key, params):
     """Stable hash of endpoint + api_key + params; truncated for filename use."""
-    blob = '{e}|{k}|{p}'.format(
-        e=endpoint, k=api_key,
-        p=json.dumps(params or {}, sort_keys=True, default=str),
-    )
+    serialized = json.dumps(params or {}, sort_keys=True, default=str)
+    blob = f'{endpoint}|{api_key}|{serialized}'
     return hashlib.sha256(blob.encode('utf-8')).hexdigest()[:16]
 
 
@@ -221,9 +219,10 @@ def _cache_path(endpoint, api_key, params):
         os.makedirs(CACHE_DIR, exist_ok=True)
     except OSError:
         return None
-    return os.path.join(CACHE_DIR, '{e}-{h}.json'.format(
-        e=endpoint, h=_cache_key(endpoint, api_key, params),
-    ))
+    return os.path.join(
+        CACHE_DIR,
+        f'{endpoint}-{_cache_key(endpoint, api_key, params)}.json',
+    )
 
 
 def _cache_read(endpoint, api_key, params):
@@ -286,11 +285,8 @@ def _request(module, api_key, endpoint, params, result_key):
     if endpoint in _CACHEABLE_GETS:
         cached = _cache_read(endpoint, api_key, params)
         if cached is not None:
-            module.log('uptimerobot: cache HIT {endpoint} ({n} items, ttl={ttl}s)'.format(
-                endpoint=endpoint,
-                n=len(cached) if isinstance(cached, list) else 1,
-                ttl=CACHE_TTL_SECONDS,
-            ))
+            n = len(cached) if isinstance(cached, list) else 1
+            module.log(f'uptimerobot: cache HIT {endpoint} ({n} items, ttl={CACHE_TTL_SECONDS}s)')
             return True, cached
 
     success, result = _request_uncached(module, api_key, endpoint, params, result_key)
@@ -310,13 +306,10 @@ def _request_uncached(module, api_key, endpoint, params, result_key):
     body['api_key'] = api_key
     body['format'] = 'json'
 
-    module.log('uptimerobot: POST {endpoint} keys={keys}'.format(
-        endpoint=endpoint, keys=_safe_keys(params),
-    ))
+    module.log(f'uptimerobot: POST {endpoint} keys={_safe_keys(params)}')
 
     aggregated = []
     offset = 0
-    is_paginated_field = None
     pages = 0
 
     while True:
@@ -341,9 +334,7 @@ def _request_uncached(module, api_key, endpoint, params, result_key):
             retry_after = int(info.get('retry-after') or DEFAULT_RATE_LIMIT_RETRY_SECONDS)
             sleep_for = min(retry_after, 60)
             module.warn(
-                'uptimerobot: rate limited on {endpoint} (HTTP 429); sleeping {sec}s and retrying once'.format(
-                    endpoint=endpoint, sec=sleep_for,
-                ),
+                f'uptimerobot: rate limited on {endpoint} (HTTP 429); sleeping {sleep_for}s and retrying once',
             )
             time.sleep(sleep_for)
             resp, info = fetch_url(
@@ -357,46 +348,31 @@ def _request_uncached(module, api_key, endpoint, params, result_key):
             status = info.get('status', -1)
 
         if status < 200 or status >= 300:
-            module.log('uptimerobot: POST {endpoint} -> HTTP {status}'.format(
-                endpoint=endpoint, status=status,
-            ))
-            return False, 'HTTP {status} from {url}: {msg}'.format(
-                status=status,
-                url=url,
-                msg=info.get('msg') or info.get('body') or '',
-            )
+            module.log(f'uptimerobot: POST {endpoint} -> HTTP {status}')
+            msg = info.get('msg') or info.get('body') or ''
+            return False, f'HTTP {status} from {url}: {msg}'
 
         try:
             payload = json.loads(resp.read().decode('utf-8'))
         except (ValueError, AttributeError) as exc:
-            return False, 'Could not parse JSON from {url}: {exc}'.format(url=url, exc=exc)
+            return False, f'Could not parse JSON from {url}: {exc}'
 
         if payload.get('stat') != 'ok':
             err = payload.get('error') or {}
-            module.log('uptimerobot: POST {endpoint} stat=fail type={type}'.format(
-                endpoint=endpoint, type=err.get('type', 'unknown'),
-            ))
-            return False, '{type}: {message}'.format(
-                type=err.get('type', 'unknown'),
-                message=err.get('message', payload),
-            )
+            module.log(f"uptimerobot: POST {endpoint} stat=fail type={err.get('type', 'unknown')}")
+            return False, f"{err.get('type', 'unknown')}: {err.get('message', payload)}"
 
         if payload.get(result_key) is None:
             # Some endpoints return only `stat: 'ok'` (e.g. delete, edit when no
             # detail is included). Fall back to the message field if present.
-            module.log('uptimerobot: POST {endpoint} stat=ok (no {key} in payload)'.format(
-                endpoint=endpoint, key=result_key,
-            ))
+            module.log(f'uptimerobot: POST {endpoint} stat=ok (no {result_key} in payload)')
             return True, payload.get('message', payload)
 
         item = payload[result_key]
         if isinstance(item, list):
             aggregated += item
-            is_paginated_field = True
         else:
-            module.log('uptimerobot: POST {endpoint} stat=ok pages={pages}'.format(
-                endpoint=endpoint, pages=pages,
-            ))
+            module.log(f'uptimerobot: POST {endpoint} stat=ok pages={pages}')
             return True, item
 
         pagination = payload.get('pagination') or {}
@@ -407,10 +383,8 @@ def _request_uncached(module, api_key, endpoint, params, result_key):
             break
         offset += PAGE_SIZE
 
-    module.log('uptimerobot: POST {endpoint} stat=ok pages={pages} items={n}'.format(
-        endpoint=endpoint, pages=pages, n=len(aggregated),
-    ))
-    return True, aggregated if is_paginated_field else aggregated
+    module.log(f'uptimerobot: POST {endpoint} stat=ok pages={pages} items={len(aggregated)}')
+    return True, aggregated
 
 
 def _filter_keys(params, allowed):
@@ -481,6 +455,9 @@ def get_monitors(module, api_key, search=None):
     success, monitors = _request(module, api_key, 'getMonitors', params, 'monitors')
     if not success:
         return success, monitors
+    if not isinstance(monitors, list):
+        # an endpoint that returned only `stat: ok` yields the message fallback
+        return True, monitors
     for item in monitors:
         _translate_monitor_response(item)
     return True, monitors
@@ -552,6 +529,8 @@ def get_mwindows(module, api_key):
     success, mwindows = _request(module, api_key, 'getMWindows', {}, 'mwindows')
     if not success:
         return success, mwindows
+    if not isinstance(mwindows, list):
+        return True, mwindows
     for item in mwindows:
         _translate_mwindow_response(item)
     return True, mwindows
@@ -616,6 +595,8 @@ def get_psps(module, api_key):
     success, psps = _request(module, api_key, 'getPSPs', {}, 'psps')
     if not success:
         return success, psps
+    if not isinstance(psps, list):
+        return True, psps
     for item in psps:
         _translate_psp_response(item)
     return True, psps
@@ -676,6 +657,8 @@ def get_alert_contacts(module, api_key):
     success, contacts = _request(module, api_key, 'getAlertContacts', {}, 'alert_contacts')
     if not success:
         return success, contacts
+    if not isinstance(contacts, list):
+        return True, contacts
     for item in contacts:
         _translate_alert_contact_response(item)
     return True, contacts
@@ -728,9 +711,7 @@ def resolve_friendly_names(items, names, kind):
     for name in names:
         if name not in by_name:
             raise ValueError(
-                '{kind} with friendly_name {name!r} not found on UptimeRobot'.format(
-                    kind=kind, name=name,
-                ),
+                f'{kind} with friendly_name {name!r} not found on UptimeRobot',
             )
         out.append(int(by_name[name]['id']))
     return out

--- a/plugins/modules/uptimerobot_account_info.py
+++ b/plugins/modules/uptimerobot_account_info.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -100,11 +102,12 @@ def main():
     module.log('uptimerobot_account_info: fetching account details')
     success, account = ur.get_account_details(module, api_key)
     if not success:
-        module.fail_json(msg='Could not fetch UptimeRobot account details: {0}'.format(account))
-    module.log('uptimerobot_account_info: monitor_limit={0} up={1} down={2} paused={3}'.format(
-        account.get('monitor_limit'), account.get('up_monitors'),
-        account.get('down_monitors'), account.get('paused_monitors'),
-    ))
+        module.fail_json(msg=f'Could not fetch UptimeRobot account details: {account}')
+    module.log(
+        f"uptimerobot_account_info: monitor_limit={account.get('monitor_limit')} "
+        f"up={account.get('up_monitors')} down={account.get('down_monitors')} "
+        f"paused={account.get('paused_monitors')}"
+    )
     module.exit_json(changed=False, account=account, debug={
         'operation': 'read',
         'fields': sorted(account.keys()) if isinstance(account, dict) else None,

--- a/plugins/modules/uptimerobot_alert_contact.py
+++ b/plugins/modules/uptimerobot_alert_contact.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -120,15 +122,13 @@ def main():
     contact_id = module.params.get('id')
     friendly_name = module.params.get('friendly_name')
 
-    module.log('uptimerobot_alert_contact: looking up id={0} friendly_name={1!r}'.format(
-        contact_id, friendly_name,
-    ))
+    module.log(f'uptimerobot_alert_contact: looking up id={contact_id} friendly_name={friendly_name!r}')
 
     target = None
     if contact_id is None:
         success, contacts = ur.get_alert_contacts(module, api_key)
         if not success:
-            module.fail_json(msg='Could not list alert contacts: {0}'.format(contacts))
+            module.fail_json(msg=f'Could not list alert contacts: {contacts}')
         target = ur.find_by_friendly_name(contacts, friendly_name)
         if target is None:
             module.exit_json(changed=False, alert_contact={}, debug={
@@ -162,12 +162,13 @@ def main():
             'friendly_name': target.get('friendly_name'),
         })
 
-    module.log('uptimerobot_alert_contact: deleting id={0} friendly_name={1!r}'.format(
-        contact_id, target.get('friendly_name'),
-    ))
+    module.log(
+        f"uptimerobot_alert_contact: deleting id={contact_id} "
+        f"friendly_name={target.get('friendly_name')!r}"
+    )
     success, result = ur.delete_alert_contact(module, api_key, contact_id)
     if not success:
-        module.fail_json(msg='Could not delete alert contact {0!r}: {1}'.format(target, result))
+        module.fail_json(msg=f'Could not delete alert contact {target!r}: {result}')
     module.exit_json(changed=True, alert_contact=target, debug={
         'operation': 'delete',
         'contact_id': contact_id,

--- a/plugins/modules/uptimerobot_alert_contact_info.py
+++ b/plugins/modules/uptimerobot_alert_contact_info.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -103,7 +105,7 @@ def main():
     module.log('uptimerobot_alert_contact_info: fetching alert contacts')
     success, contacts = ur.get_alert_contacts(module, api_key)
     if not success:
-        module.fail_json(msg='Could not list alert contacts: {0}'.format(contacts))
+        module.fail_json(msg=f'Could not list alert contacts: {contacts}')
 
     if friendly_name:
         match = ur.find_by_friendly_name(contacts, friendly_name)

--- a/plugins/modules/uptimerobot_monitor.py
+++ b/plugins/modules/uptimerobot_monitor.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -340,7 +342,7 @@ def _build_alert_contacts(module, api_key, items):
     if needs_resolution:
         success, contacts = ur.get_alert_contacts(module, api_key)
         if not success:
-            module.fail_json(msg='Could not list alert contacts: {0}'.format(contacts))
+            module.fail_json(msg=f'Could not list alert contacts: {contacts}')
         by_name = {c.get('friendly_name'): c for c in contacts}
 
     resolved = []
@@ -349,7 +351,7 @@ def _build_alert_contacts(module, api_key, items):
         if contact_id is None:
             name = item['friendly_name']
             if name not in by_name:
-                module.fail_json(msg='Alert contact {0!r} not found on UptimeRobot'.format(name))
+                module.fail_json(msg=f'Alert contact {name!r} not found on UptimeRobot')
             contact_id = int(by_name[name]['id'])
         resolved.append({
             'id': contact_id,
@@ -367,7 +369,7 @@ def _build_mwindows(module, api_key, items):
     if needs_resolution:
         success, mwindows = ur.get_mwindows(module, api_key)
         if not success:
-            module.fail_json(msg='Could not list maintenance windows: {0}'.format(mwindows))
+            module.fail_json(msg=f'Could not list maintenance windows: {mwindows}')
         by_name = {m.get('friendly_name'): m for m in mwindows}
 
     ids = []
@@ -376,7 +378,7 @@ def _build_mwindows(module, api_key, items):
         if wid is None:
             name = item['friendly_name']
             if name not in by_name:
-                module.fail_json(msg='Maintenance window {0!r} not found on UptimeRobot'.format(name))
+                module.fail_json(msg=f'Maintenance window {name!r} not found on UptimeRobot')
             wid = int(by_name[name]['id'])
         ids.append(int(wid))
     return ur.mwindows_wire(ids)
@@ -467,17 +469,15 @@ def main():
     friendly_name = module.params['friendly_name']
     state = module.params['state']
 
-    module.log('uptimerobot_monitor: looking up friendly_name={0!r}'.format(friendly_name))
+    module.log(f'uptimerobot_monitor: looking up friendly_name={friendly_name!r}')
 
     # Step 1: locate the monitor by friendly_name. We can't trust `search` to
     # be exact-match, so list all and filter ourselves.
     success, monitors = ur.get_monitors(module, api_key)
     if not success:
-        module.fail_json(msg='Could not list monitors: {0}'.format(monitors))
+        module.fail_json(msg=f'Could not list monitors: {monitors}')
     current = ur.find_by_friendly_name(monitors, friendly_name)
-    module.log('uptimerobot_monitor: existing={0} (out of {1} monitors on the account)'.format(
-        bool(current), len(monitors),
-    ))
+    module.log(f'uptimerobot_monitor: existing={bool(current)} (out of {len(monitors)} monitors on the account)')
 
     # Step 2: build the desired payload (only fields the user actually set).
     desired = {}
@@ -520,12 +520,10 @@ def main():
                     'friendly_name': friendly_name,
                     'monitor_id': current['id'],
                 })
-        module.log('uptimerobot_monitor: deleting id={0} friendly_name={1!r}'.format(
-            current['id'], friendly_name,
-        ))
+        module.log(f"uptimerobot_monitor: deleting id={current['id']} friendly_name={friendly_name!r}")
         success, result = ur.delete_monitor(module, api_key, current['id'])
         if not success:
-            module.fail_json(msg='Could not delete monitor {0!r}: {1}'.format(friendly_name, result))
+            module.fail_json(msg=f'Could not delete monitor {friendly_name!r}: {result}')
         module.exit_json(changed=True, monitor=current,
             diff={'before': delete_before, 'after': {}},
             debug={
@@ -555,12 +553,10 @@ def main():
                     'friendly_name': friendly_name,
                     'sent_keys': sorted(body.keys()),
                 })
-        module.log('uptimerobot_monitor: creating friendly_name={0!r} sent_keys={1}'.format(
-            friendly_name, sorted(body.keys()),
-        ))
+        module.log(f'uptimerobot_monitor: creating friendly_name={friendly_name!r} sent_keys={sorted(body.keys())}')
         success, result = ur.new_monitor(module, api_key, body)
         if not success:
-            module.fail_json(msg='Could not create monitor {0!r}: {1}'.format(friendly_name, result))
+            module.fail_json(msg=f'Could not create monitor {friendly_name!r}: {result}')
         module.exit_json(changed=True, monitor=result,
             diff=create_diff,
             debug={
@@ -614,7 +610,7 @@ def main():
     field_diff = ur.diff_for_update(current_compare, desired_compare, diff_fields)
 
     if not field_diff:
-        module.log('uptimerobot_monitor: id={0} no diff -> changed=false'.format(current['id']))
+        module.log(f"uptimerobot_monitor: id={current['id']} no diff -> changed=false")
         module.exit_json(changed=False, monitor=current, debug={
             'operation': 'noop',
             'reason': 'no diff',
@@ -622,9 +618,7 @@ def main():
             'monitor_id': current['id'],
         })
 
-    module.log('uptimerobot_monitor: id={0} diff_fields={1}'.format(
-        current['id'], sorted(field_diff.keys()),
-    ))
+    module.log(f"uptimerobot_monitor: id={current['id']} diff_fields={sorted(field_diff.keys())}")
 
     update_diff = {
         'before': {k: current_compare.get(k) for k in field_diff},
@@ -647,7 +641,7 @@ def main():
     body['id'] = current['id']
     success, result = ur.edit_monitor(module, api_key, body)
     if not success:
-        module.fail_json(msg='Could not edit monitor {0!r}: {1}'.format(friendly_name, result))
+        module.fail_json(msg=f'Could not edit monitor {friendly_name!r}: {result}')
     module.exit_json(changed=True, monitor=result,
         diff=update_diff,
         debug={

--- a/plugins/modules/uptimerobot_monitor_info.py
+++ b/plugins/modules/uptimerobot_monitor_info.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -129,10 +131,10 @@ def main():
     search = module.params.get('search') or None
     friendly_name = module.params.get('friendly_name')
 
-    module.log('uptimerobot_monitor_info: fetching monitors search={0!r}'.format(search))
+    module.log(f'uptimerobot_monitor_info: fetching monitors search={search!r}')
     success, monitors = ur.get_monitors(module, api_key, search=search)
     if not success:
-        module.fail_json(msg='Could not list monitors: {0}'.format(monitors))
+        module.fail_json(msg=f'Could not list monitors: {monitors}')
 
     if friendly_name:
         match = ur.find_by_friendly_name(monitors, friendly_name)

--- a/plugins/modules/uptimerobot_mwindow.py
+++ b/plugins/modules/uptimerobot_mwindow.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -152,7 +154,7 @@ def _synthesise_name(params):
     parts = [params['type']]
     if params.get('value'):
         parts.append(str(params['value']))
-    parts.append('{0}-{1}'.format(params['start_time'], params['end_time']))
+    parts.append(f"{params['start_time']}-{params['end_time']}")
     return ' '.join(parts)
 
 
@@ -186,14 +188,12 @@ def main():
             module.fail_json(msg='Either pass `friendly_name` or pass `type`, `start_time`, `end_time` so it can be synthesised.')
         friendly_name = _synthesise_name(module.params)
 
-    module.log('uptimerobot_mwindow: looking up friendly_name={0!r}'.format(friendly_name))
+    module.log(f'uptimerobot_mwindow: looking up friendly_name={friendly_name!r}')
     success, mwindows = ur.get_mwindows(module, api_key)
     if not success:
-        module.fail_json(msg='Could not list maintenance windows: {0}'.format(mwindows))
+        module.fail_json(msg=f'Could not list maintenance windows: {mwindows}')
     current = ur.find_by_friendly_name(mwindows, friendly_name) if friendly_name else None
-    module.log('uptimerobot_mwindow: existing={0} (out of {1} mwindows on the account)'.format(
-        bool(current), len(mwindows),
-    ))
+    module.log(f'uptimerobot_mwindow: existing={bool(current)} (out of {len(mwindows)} mwindows on the account)')
 
     if state == 'absent':
         if current is None:
@@ -215,10 +215,10 @@ def main():
                     'friendly_name': friendly_name,
                     'mwindow_id': current['id'],
                 })
-        module.log('uptimerobot_mwindow: deleting id={0}'.format(current['id']))
+        module.log(f"uptimerobot_mwindow: deleting id={current['id']}")
         success, result = ur.delete_mwindow(module, api_key, current['id'])
         if not success:
-            module.fail_json(msg='Could not delete maintenance window {0!r}: {1}'.format(friendly_name, result))
+            module.fail_json(msg=f'Could not delete maintenance window {friendly_name!r}: {result}')
         module.exit_json(changed=True, mwindow=current,
             diff={'before': delete_before, 'after': {}},
             debug={
@@ -248,7 +248,7 @@ def main():
         # Create. type/start_time/duration are required for new mwindows.
         for required in ('type', 'start_time'):
             if not desired.get(required):
-                module.fail_json(msg='`{0}` is required when creating a new maintenance window.'.format(required))
+                module.fail_json(msg=f'`{required}` is required when creating a new maintenance window.')
         if not desired.get('duration'):
             module.fail_json(msg='Either `end_time` or `duration` is required when creating a new maintenance window.')
         # `status` not honoured on create.
@@ -263,12 +263,10 @@ def main():
                     'friendly_name': friendly_name,
                     'sent_keys': sorted(body.keys()),
                 })
-        module.log('uptimerobot_mwindow: creating friendly_name={0!r} sent_keys={1}'.format(
-            friendly_name, sorted(body.keys()),
-        ))
+        module.log(f'uptimerobot_mwindow: creating friendly_name={friendly_name!r} sent_keys={sorted(body.keys())}')
         success, result = ur.new_mwindow(module, api_key, body)
         if not success:
-            module.fail_json(msg='Could not create maintenance window {0!r}: {1}'.format(friendly_name, result))
+            module.fail_json(msg=f'Could not create maintenance window {friendly_name!r}: {result}')
         module.exit_json(changed=True, mwindow=result,
             diff=create_diff,
             debug={
@@ -288,7 +286,7 @@ def main():
     current_compare = {field: current.get(field) for field in diff_fields}
     field_diff = ur.diff_for_update(current_compare, desired, diff_fields)
     if not field_diff:
-        module.log('uptimerobot_mwindow: id={0} no diff -> changed=false'.format(current['id']))
+        module.log(f"uptimerobot_mwindow: id={current['id']} no diff -> changed=false")
         module.exit_json(changed=False, mwindow=current, debug={
             'operation': 'noop',
             'reason': 'no diff',
@@ -296,9 +294,7 @@ def main():
             'mwindow_id': current['id'],
         })
 
-    module.log('uptimerobot_mwindow: id={0} diff_fields={1}'.format(
-        current['id'], sorted(field_diff.keys()),
-    ))
+    module.log(f"uptimerobot_mwindow: id={current['id']} diff_fields={sorted(field_diff.keys())}")
 
     update_diff = {
         'before': {k: current_compare.get(k) for k in field_diff},
@@ -321,7 +317,7 @@ def main():
     body['id'] = current['id']
     success, result = ur.edit_mwindow(module, api_key, body)
     if not success:
-        module.fail_json(msg='Could not edit maintenance window {0!r}: {1}'.format(friendly_name, result))
+        module.fail_json(msg=f'Could not edit maintenance window {friendly_name!r}: {result}')
     module.exit_json(changed=True, mwindow=result,
         diff=update_diff,
         debug={

--- a/plugins/modules/uptimerobot_mwindow_info.py
+++ b/plugins/modules/uptimerobot_mwindow_info.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -104,7 +106,7 @@ def main():
     module.log('uptimerobot_mwindow_info: fetching maintenance windows')
     success, mwindows = ur.get_mwindows(module, api_key)
     if not success:
-        module.fail_json(msg='Could not list maintenance windows: {0}'.format(mwindows))
+        module.fail_json(msg=f'Could not list maintenance windows: {mwindows}')
 
     if friendly_name:
         match = ur.find_by_friendly_name(mwindows, friendly_name)

--- a/plugins/modules/uptimerobot_psp.py
+++ b/plugins/modules/uptimerobot_psp.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -145,7 +147,7 @@ def _resolve_monitor_ids(module, api_key, items):
     if needs_resolution:
         success, monitors = ur.get_monitors(module, api_key)
         if not success:
-            module.fail_json(msg='Could not list monitors: {0}'.format(monitors))
+            module.fail_json(msg=f'Could not list monitors: {monitors}')
         by_name = {m.get('friendly_name'): m for m in monitors}
     ids = []
     for item in items:
@@ -153,7 +155,7 @@ def _resolve_monitor_ids(module, api_key, items):
         if mid is None:
             name = item['friendly_name']
             if name not in by_name:
-                module.fail_json(msg='Monitor {0!r} not found on UptimeRobot'.format(name))
+                module.fail_json(msg=f'Monitor {name!r} not found on UptimeRobot')
             mid = int(by_name[name]['id'])
         ids.append(int(mid))
     return ur.monitors_wire(ids)
@@ -184,14 +186,12 @@ def main():
     friendly_name = module.params['friendly_name']
     state = module.params['state']
 
-    module.log('uptimerobot_psp: looking up friendly_name={0!r}'.format(friendly_name))
+    module.log(f'uptimerobot_psp: looking up friendly_name={friendly_name!r}')
     success, psps = ur.get_psps(module, api_key)
     if not success:
-        module.fail_json(msg='Could not list PSPs: {0}'.format(psps))
+        module.fail_json(msg=f'Could not list PSPs: {psps}')
     current = ur.find_by_friendly_name(psps, friendly_name)
-    module.log('uptimerobot_psp: existing={0} (out of {1} PSPs on the account)'.format(
-        bool(current), len(psps),
-    ))
+    module.log(f'uptimerobot_psp: existing={bool(current)} (out of {len(psps)} PSPs on the account)')
 
     if state == 'absent':
         if current is None:
@@ -213,10 +213,10 @@ def main():
                     'friendly_name': friendly_name,
                     'psp_id': current['id'],
                 })
-        module.log('uptimerobot_psp: deleting id={0}'.format(current['id']))
+        module.log(f"uptimerobot_psp: deleting id={current['id']}")
         success, result = ur.delete_psp(module, api_key, current['id'])
         if not success:
-            module.fail_json(msg='Could not delete PSP {0!r}: {1}'.format(friendly_name, result))
+            module.fail_json(msg=f'Could not delete PSP {friendly_name!r}: {result}')
         module.exit_json(changed=True, psp=current,
             diff={'before': delete_before, 'after': {}},
             debug={
@@ -252,12 +252,10 @@ def main():
                     'friendly_name': friendly_name,
                     'sent_keys': sorted(body.keys()),
                 })
-        module.log('uptimerobot_psp: creating friendly_name={0!r} sent_keys={1}'.format(
-            friendly_name, sorted(body.keys()),
-        ))
+        module.log(f'uptimerobot_psp: creating friendly_name={friendly_name!r} sent_keys={sorted(body.keys())}')
         success, result = ur.new_psp(module, api_key, body)
         if not success:
-            module.fail_json(msg='Could not create PSP {0!r}: {1}'.format(friendly_name, result))
+            module.fail_json(msg=f'Could not create PSP {friendly_name!r}: {result}')
         module.exit_json(changed=True, psp=result,
             diff=create_diff,
             debug={
@@ -284,7 +282,7 @@ def main():
     diff_fields = ['monitors', 'custom_domain', 'sort', 'hide_url_links', 'status']
     field_diff = ur.diff_for_update(current_compare, desired_compare, diff_fields)
     if not field_diff and 'password' not in desired:
-        module.log('uptimerobot_psp: id={0} no diff -> changed=false'.format(current['id']))
+        module.log(f"uptimerobot_psp: id={current['id']} no diff -> changed=false")
         module.exit_json(changed=False, psp=current, debug={
             'operation': 'noop',
             'reason': 'no diff',
@@ -292,10 +290,10 @@ def main():
             'psp_id': current['id'],
         })
 
-    module.log('uptimerobot_psp: id={0} diff_fields={1}{2}'.format(
-        current['id'], sorted(field_diff.keys()),
-        ' (+password)' if 'password' in desired else '',
-    ))
+    module.log(
+        f"uptimerobot_psp: id={current['id']} diff_fields={sorted(field_diff.keys())}"
+        f"{' (+password)' if 'password' in desired else ''}"
+    )
 
     update_diff = {
         'before': {k: current_compare.get(k) for k in field_diff},
@@ -322,7 +320,7 @@ def main():
     body['id'] = current['id']
     success, result = ur.edit_psp(module, api_key, body)
     if not success:
-        module.fail_json(msg='Could not edit PSP {0!r}: {1}'.format(friendly_name, result))
+        module.fail_json(msg=f'Could not edit PSP {friendly_name!r}: {result}')
     module.exit_json(changed=True, psp=result,
         diff=update_diff,
         debug={

--- a/plugins/modules/uptimerobot_psp_info.py
+++ b/plugins/modules/uptimerobot_psp_info.py
@@ -1,8 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: (c) 2026, Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
-# The Unlicense (see LICENSE or https://unlicense.org/)
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
 
 from __future__ import absolute_import, division, print_function
 
@@ -102,7 +104,7 @@ def main():
     module.log('uptimerobot_psp_info: fetching public status pages')
     success, psps = ur.get_psps(module, api_key)
     if not success:
-        module.fail_json(msg='Could not list PSPs: {0}'.format(psps))
+        module.fail_json(msg=f'Could not list PSPs: {psps}')
 
     if friendly_name:
         match = ur.find_by_friendly_name(psps, friendly_name)

--- a/tests/unit/plugins/module_utils/test_uptimerobot.py
+++ b/tests/unit/plugins/module_utils/test_uptimerobot.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
+
+"""Unit tests for the uptimerobot module_util pure helpers.
+
+These cover the wire-format builders, the secret-redaction helper, the
+cache-key hashing, the friendly-name resolution and the read-direction
+response translators (which encode the idempotency-critical mapping
+between UptimeRobot integer IDs and the human-readable labels). All are
+pure functions; no HTTP and no filesystem is touched. The collection
+import is wired up by tests/conftest.py.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.linuxfabrik.lfops.plugins.module_utils import uptimerobot as ur
+
+
+class TestWireBuilders(unittest.TestCase):
+
+    def test_alert_contacts_wire_with_defaults(self):
+        wire = ur.alert_contacts_wire([{'id': 1, 'threshold': 5, 'recurrence': 0}, {'id': 2}])
+        self.assertEqual(wire, '1_5_0-2_0_0')
+
+    def test_mwindows_wire(self):
+        self.assertEqual(ur.mwindows_wire([3, 4, 5]), '3-4-5')
+
+    def test_monitors_wire(self):
+        self.assertEqual(ur.monitors_wire([7, 8]), '7,8')
+
+
+class TestTranslateHelpers(unittest.TestCase):
+
+    def test_translate_known_and_unknown(self):
+        self.assertEqual(ur._translate('http', ur.MONITOR_TYPE), 1)
+        self.assertEqual(ur._translate('nope', ur.MONITOR_TYPE), 'nope')
+        # non-string passes through untouched
+        self.assertEqual(ur._translate(5, ur.MONITOR_TYPE), 5)
+
+    def test_filter_keys_drops_unknown_and_empty(self):
+        out = ur._filter_keys({'a': 1, 'b': None, 'c': '', 'd': 'x'}, {'a', 'b', 'c'})
+        self.assertEqual(out, {'a': 1})
+
+    def test_translate_keys_only_strings(self):
+        params = {'type': 'http', 'interval': 300}
+        ur._translate_keys(params, {'type': ur.MONITOR_TYPE})
+        self.assertEqual(params['type'], 1)
+        self.assertEqual(params['interval'], 300)
+
+
+class TestSafeKeysAndCache(unittest.TestCase):
+
+    def test_safe_keys_redacts_secrets(self):
+        self.assertEqual(
+            ur._safe_keys({'api_key': 'x', 'password': 'y', 'friendly_name': 'n'}),
+            ['api_key=<redacted>', 'friendly_name', 'password=<redacted>'],
+        )
+
+    def test_cache_key_stable_and_param_sensitive(self):
+        a = ur._cache_key('getMonitors', 'k', {'x': 1})
+        b = ur._cache_key('getMonitors', 'k', {'x': 1})
+        c = ur._cache_key('getMonitors', 'k', {'x': 2})
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+
+
+class TestFriendlyNames(unittest.TestCase):
+
+    def test_find_by_friendly_name(self):
+        items = [{'friendly_name': 'a'}, {'friendly_name': 'b'}]
+        self.assertEqual(ur.find_by_friendly_name(items, 'b'), {'friendly_name': 'b'})
+        self.assertIsNone(ur.find_by_friendly_name(items, 'missing'))
+
+    def test_resolve_friendly_names_ok(self):
+        items = [{'friendly_name': 'a', 'id': 1}, {'friendly_name': 'b', 'id': 2}]
+        self.assertEqual(ur.resolve_friendly_names(items, ['b', 'a'], 'monitor'), [2, 1])
+
+    def test_resolve_friendly_names_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            ur.resolve_friendly_names([{'friendly_name': 'a', 'id': 1}], ['zzz'], 'monitor')
+
+
+class TestDiffForUpdate(unittest.TestCase):
+
+    def test_diff_compares_stringified(self):
+        # int 1 vs string '1' must be considered equal (no spurious change)
+        out = ur.diff_for_update({'x': 1, 'y': 2}, {'x': '1', 'y': '3'}, ['x', 'y'])
+        self.assertEqual(out, {'y': '3'})
+
+    def test_diff_skips_fields_not_in_desired(self):
+        out = ur.diff_for_update({'x': 1}, {}, ['x'])
+        self.assertEqual(out, {})
+
+
+class TestResponseTranslators(unittest.TestCase):
+
+    def test_monitor_response_maps_ids_to_labels(self):
+        item = {'type': 1, 'status': 2, 'http_method': 2, 'auth_type': 1}
+        ur._translate_monitor_response(item)
+        self.assertEqual(item['type'], 'http')
+        self.assertEqual(item['status'], 'up')
+        self.assertEqual(item['http_method'], 'get')
+        # auth_type is mirrored to http_auth_type (write-side name)
+        self.assertEqual(item['http_auth_type'], 'basic')
+
+    def test_mwindow_response_translates_weekly_days(self):
+        item = {'type': 3, 'status': 1, 'value': '1-3-5'}
+        ur._translate_mwindow_response(item)
+        self.assertEqual(item['type'], 'weekly')
+        self.assertEqual(item['status'], 'active')
+        self.assertEqual(item['value'], 'mon-wed-fri')
+
+    def test_psp_response_mirrors_custom_url(self):
+        item = {'sort': 1, 'status': 1, 'custom_url': 'status.example.com'}
+        ur._translate_psp_response(item)
+        self.assertEqual(item['sort'], 'a-z')
+        self.assertEqual(item['status'], 'active')
+        self.assertEqual(item['custom_domain'], 'status.example.com')
+
+    def test_alert_contact_response_maps_ids(self):
+        item = {'status': 2, 'type': 2}
+        ur._translate_alert_contact_response(item)
+        self.assertEqual(item['status'], 'active')
+        self.assertEqual(item['type'], 'email')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_uptimerobot_monitor.py
+++ b/tests/unit/plugins/modules/test_uptimerobot_monitor.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
+
+"""Unit tests for the uptimerobot_monitor pure normalizers.
+
+These reduce the API form and the user/wire form of alert_contacts and
+mwindows to the same canonical, order-independent string, which is what
+keeps the module idempotent. The collection import is wired up by
+tests/conftest.py.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.linuxfabrik.lfops.plugins.modules import uptimerobot_monitor as mod
+
+
+class TestNormalizeAlertContacts(unittest.TestCase):
+
+    def test_current_is_sorted_by_id(self):
+        current = [
+            {'id': 2, 'threshold': 5, 'recurrence': 0, 'friendly_name': 'b'},
+            {'id': 1, 'threshold': 0, 'recurrence': 0, 'friendly_name': 'a'},
+        ]
+        self.assertEqual(mod._normalize_current_alert_contacts(current), '1_0_0-2_5_0')
+
+    def test_empty_current(self):
+        self.assertEqual(mod._normalize_current_alert_contacts([]), '')
+
+    def test_desired_wire_is_sorted(self):
+        self.assertEqual(mod._normalize_desired_alert_contacts('2_5_0-1_0_0'), '1_0_0-2_5_0')
+
+    def test_current_and_desired_match_when_equivalent(self):
+        current = [{'id': 1, 'threshold': 0, 'recurrence': 0},
+                   {'id': 2, 'threshold': 5, 'recurrence': 0}]
+        self.assertEqual(
+            mod._normalize_current_alert_contacts(current),
+            mod._normalize_desired_alert_contacts('2_5_0-1_0_0'),
+        )
+
+
+class TestNormalizeMwindows(unittest.TestCase):
+
+    def test_current_sorted(self):
+        self.assertEqual(mod._normalize_current_mwindows([{'id': 3}, {'id': 1}]), '1-3')
+
+    def test_desired_sorted(self):
+        self.assertEqual(mod._normalize_desired_mwindows('3-1-2'), '1-2-3')
+
+    def test_empty(self):
+        self.assertEqual(mod._normalize_current_mwindows([]), '')
+        self.assertEqual(mod._normalize_desired_mwindows(''), '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_uptimerobot_mwindow.py
+++ b/tests/unit/plugins/modules/test_uptimerobot_mwindow.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8; py-indent-offset: 4 -*-
+#
+# Author:  Linuxfabrik GmbH, Zurich, Switzerland
+# Contact: info (at) linuxfabrik (dot) ch
+#          https://www.linuxfabrik.ch/
+# License: The Unlicense, see LICENSE file.
+
+"""Unit tests for the uptimerobot_mwindow pure time helpers.
+
+The collection import is wired up by tests/conftest.py.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.linuxfabrik.lfops.plugins.modules import uptimerobot_mwindow as mod
+
+
+class TestHhmmToMinutes(unittest.TestCase):
+
+    def test_basic(self):
+        self.assertEqual(mod._hhmm_to_minutes('00:00'), 0)
+        self.assertEqual(mod._hhmm_to_minutes('01:30'), 90)
+        self.assertEqual(mod._hhmm_to_minutes('23:59'), 1439)
+
+
+class TestComputeDuration(unittest.TestCase):
+
+    def test_same_day(self):
+        self.assertEqual(mod._compute_duration('09:00', '17:00'), 480)
+
+    def test_wraps_over_midnight(self):
+        self.assertEqual(mod._compute_duration('22:00', '02:00'), 240)
+
+    def test_equal_start_end_is_full_day(self):
+        # duration <= 0 wraps to a full 24h window
+        self.assertEqual(mod._compute_duration('03:00', '03:00'), 1440)
+
+
+class TestSynthesiseName(unittest.TestCase):
+
+    def test_with_value(self):
+        params = {'type': 'weekly', 'value': 'mon-wed', 'start_time': '03:30', 'end_time': '05:30'}
+        self.assertEqual(mod._synthesise_name(params), 'weekly mon-wed 03:30-05:30')
+
+    def test_without_value(self):
+        params = {'type': 'daily', 'start_time': '01:00', 'end_time': '02:00'}
+        self.assertEqual(mod._synthesise_name(params), 'daily 01:00-02:00')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Phase 4: the uptimerobot family (`module_utils/uptimerobot.py` + the nine `uptimerobot_*` modules).

## Style unification (no behavior change)
* Standard Linuxfabrik file header on all ten files (also fixes the lone `module_utils` copyright line that read `Linuxfabrik` instead of `Linuxfabrik GmbH`).
* f-strings throughout, replacing all 68 `str.format()` calls. Each replacement was applied as an exact, asserted substitution and the files were syntax-checked before writing.

## Safe fixes
* The four `get_*` functions in the module_util now pass a non-list API response (the `stat: ok` message fallback) straight through instead of iterating it and crashing.
* Dropped a no-op ternary (`aggregated if is_paginated_field else aggregated`) and the now-unused `is_paginated_field` bookkeeping in `_request_uncached`.

## Deliberately deferred
The on-disk read cache behavior, duplicate-friendly_name handling, and full-payload-on-edit are unchanged (behavior-affecting; out of scope here).

## Tests
* `test_uptimerobot.py` (module_util): wire builders, `_translate`/`_filter_keys`/`_translate_keys`, `_safe_keys` redaction, `_cache_key` stability, `find_by_friendly_name`, `resolve_friendly_names`, `diff_for_update`, and all four response translators (the ID↔label mapping that keeps the modules idempotent).
* `test_uptimerobot_monitor.py`: the alert_contacts / mwindows current-vs-desired normalizers.
* `test_uptimerobot_mwindow.py`: `_hhmm_to_minutes`, `_compute_duration` (incl. midnight wrap), `_synthesise_name`.

## Validation
* Full tox matrix green (66 tests across 13 envs).
* `ansible-doc` renders all nine modules.
* pre-commit (bandit, vulture, pytest) green.

Next: Phase 5 (nextcloud / sqlite / gpg_key / ipa_diff), including the gpg_key passphrase-leak fix.