### PR TITLE
chore: unify pyproject.toml across repositories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,8 @@ repos:
     rev: '1.9.4'
     hooks:
       - id: 'bandit'
-        args:
-          - '--severity-level=low'
-          - '--confidence-level=low'
-          - '--skip=B110,B112,B311'  # graceful-degradation patterns, non-crypto randomness
+        args: ['-c', 'pyproject.toml', '--severity-level=low', '--confidence-level=low']
+        additional_dependencies: ['bandit[toml]']
         # `plugins/modules/ipa*.py` is vendored ansible-freeipa code; bandit
         # false-positives on the project's own code style (`shell=dict(...)`
         # in argument_spec triggers B604, the literal `'on_create'` sentinel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,20 @@
 # https://github.com/Linuxfabrik/lfops/issues/221) so unrelated commits
 # don't fail the hook. Drop entries from .vulture_whitelist.py as the
 # real issues are fixed.
-paths = ["plugins", ".vulture_whitelist.py"]
+paths = ['plugins', '.vulture_whitelist.py']
 min_confidence = 80
 
 [tool.pytest.ini_options]
 # Unit tests for the in-house plugins. The matrix of Python / ansible-core
 # versions is driven by tox; see tox.ini.
-testpaths = ["tests/unit"]
+testpaths = ['tests/unit']
 # importlib mode lets same-named test files live in different plugin-type
 # directories (e.g. modules/ and lookup/ both have test_bitwarden_item.py)
 # without needing __init__.py packages.
-addopts = ["--import-mode=importlib"]
+addopts = ['--import-mode=importlib']
+
+[tool.bandit]
+# B110 (try/except/pass) and B112 (try/except/continue): intentional patterns
+# for graceful degradation.
+# B311 (pseudo-random): not used for cryptographic purposes.
+skips = ['B110', 'B112', 'B311']


### PR DESCRIPTION
The lint configuration grew per repository in April 2026 instead of from a shared template, and firewallfabrik and mcp-server-icinga came from a different project skeleton. That left four dialects behind.

Unified: `line-length` is now stated explicitly as 88 everywhere (the ruff default; checklistfabrik was the outlier at 100), `[tool.ruff.format]` is byte-identical in all six repositories that run ruff, the `select` list is alphabetical, `[tool.bandit.assert_used]` uses one pattern, and strings inside `[tool.*]` are single-quoted. `[build-system]`, `[project]` and `[tool.setuptools]` are left alone: those are per-project and double quotes are the ecosystem norm there.

`target-version`, the `ignore` lists and the extra `PTH`/`TID` rules stay per repository, they follow from the codebase.