### PR TITLE
fix(roles/repo_*): deploy repository files carrying mirror credentials with mode 0600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* A repository file that carries mirror credentials is deployed with mode `0600` instead of `0644`, so an unprivileged `dnf` or `zypper` no longer lists those repositories (all `repo_*` roles).
 * **role:collabora**: A host running a Collabora version the role has no configuration template for aborts with that version and the list of supported ones, instead of failing on a missing file.
 * **role:collabora**: The `localhost` WOPI host is an ordinary entry of `collabora__coolwsd_storage_wopi__*` instead of being hard-coded in the template, so it can be dropped with `state: 'absent'` like any other host.
 * **role:php**: The PHP-FPM configuration is checked with `php-fpm --test` before the service is restarted, so a broken pool or ini aborts the run with the error message instead of taking PHP-FPM down on the restart.

--- a/roles/repo_baseos/tasks/main.yml
+++ b/roles/repo_baseos/tasks/main.yml
@@ -12,7 +12,8 @@
       dest: '/etc/yum.repos.d/{{ item | basename }}'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_baseos__basic_auth_login | default({}) | length > 0 else "0o644" }}'
     loop: '{{ __repo_baseos__repo_files }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'

--- a/roles/repo_collabora/tasks/main.yml
+++ b/roles/repo_collabora/tasks/main.yml
@@ -12,7 +12,8 @@
       dest: '/etc/yum.repos.d/Collabora.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_collabora__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_collabora_code/tasks/main.yml
+++ b/roles/repo_collabora_code/tasks/main.yml
@@ -13,7 +13,8 @@
       dest: '/etc/yum.repos.d/Collabora.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_collabora_code__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_docker/tasks/main.yml
+++ b/roles/repo_docker/tasks/main.yml
@@ -8,7 +8,8 @@
       dest: '/etc/yum.repos.d/docker-ce.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_docker__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_elasticsearch/tasks/RedHat.yml
+++ b/roles/repo_elasticsearch/tasks/RedHat.yml
@@ -8,7 +8,8 @@
       dest: '/etc/yum.repos.d/elasticsearch.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_elasticsearch__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_epel/tasks/main.yml
+++ b/roles/repo_epel/tasks/main.yml
@@ -17,7 +17,8 @@
       dest: '/etc/yum.repos.d/{{ item | basename }}'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_epel__basic_auth_login | default({}) | length > 0 else "0o644" }}'
     loop: '{{ __repo_epel__repo_files }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'

--- a/roles/repo_gitlab_ce/tasks/main.yml
+++ b/roles/repo_gitlab_ce/tasks/main.yml
@@ -8,7 +8,8 @@
       dest: '/etc/yum.repos.d/gitlab_gitlab-ce.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_gitlab_ce__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_gitlab_runner/tasks/main.yml
+++ b/roles/repo_gitlab_runner/tasks/main.yml
@@ -7,7 +7,8 @@
       dest: '/etc/yum.repos.d/gitlab_gitlab-ce.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_gitlab_runner__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_grafana/tasks/RedHat.yml
+++ b/roles/repo_grafana/tasks/RedHat.yml
@@ -22,7 +22,8 @@
       dest: '/etc/yum.repos.d/grafana.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_grafana__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_graylog/tasks/RedHat.yml
+++ b/roles/repo_graylog/tasks/RedHat.yml
@@ -24,7 +24,8 @@
       dest: '/etc/yum.repos.d/graylog.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_graylog__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_icinga/tasks/RedHat.yml
+++ b/roles/repo_icinga/tasks/RedHat.yml
@@ -22,7 +22,8 @@
       dest: '/etc/yum.repos.d/ICINGA-release.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_icinga__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:
@@ -38,7 +39,8 @@
       dest: '/etc/yum.repos.d/ICINGA-snapshot.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_icinga__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_icinga/tasks/Suse.yml
+++ b/roles/repo_icinga/tasks/Suse.yml
@@ -29,7 +29,8 @@
       dest: '/etc/zypp/repos.d/ICINGA-release.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_icinga__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:
@@ -45,7 +46,8 @@
       dest: '/etc/zypp/repos.d/ICINGA-snapshot.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_icinga__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_influxdb/tasks/RedHat.yml
+++ b/roles/repo_influxdb/tasks/RedHat.yml
@@ -21,7 +21,8 @@
       dest: '/etc/yum.repos.d/influxdb.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_influxdb__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_mariadb/tasks/RedHat.yml
+++ b/roles/repo_mariadb/tasks/RedHat.yml
@@ -17,7 +17,8 @@
       dest: '/etc/yum.repos.d/MariaDB.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_mariadb__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_mongodb/tasks/RedHat.yml
+++ b/roles/repo_mongodb/tasks/RedHat.yml
@@ -24,7 +24,8 @@
       dest: '/etc/yum.repos.d/mongodb-org.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_mongodb__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_monitoring_plugins/tasks/RedHat.yml
+++ b/roles/repo_monitoring_plugins/tasks/RedHat.yml
@@ -34,7 +34,8 @@
       dest: '/etc/yum.repos.d/linuxfabrik-monitoring-plugins.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_monitoring_plugins__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   tags:
     - 'repo_monitoring_plugins'

--- a/roles/repo_monitoring_plugins/tasks/Suse.yml
+++ b/roles/repo_monitoring_plugins/tasks/Suse.yml
@@ -29,7 +29,8 @@
       dest: '/etc/zypp/repos.d/linuxfabrik-monitoring-plugins.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_monitoring_plugins__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   tags:
     - 'repo_monitoring_plugins'

--- a/roles/repo_mydumper/tasks/RedHat.yml
+++ b/roles/repo_mydumper/tasks/RedHat.yml
@@ -7,7 +7,8 @@
       dest: '/etc/yum.repos.d/mydumper.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_mydumper__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   tags:
     - 'repo_mydumper'

--- a/roles/repo_opensearch/tasks/RedHat.yml
+++ b/roles/repo_opensearch/tasks/RedHat.yml
@@ -23,7 +23,8 @@
       dest: '/etc/yum.repos.d/opensearch.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_opensearch__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_postgresql/tasks/main.yml
+++ b/roles/repo_postgresql/tasks/main.yml
@@ -15,7 +15,8 @@
       dest: '/etc/yum.repos.d/pgdg-redhat-all.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_postgresql__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_proxysql/tasks/RedHat.yml
+++ b/roles/repo_proxysql/tasks/RedHat.yml
@@ -24,7 +24,8 @@
       dest: '/etc/yum.repos.d/proxysql.repo'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_proxysql__basic_auth_login | default({}) | length > 0 else "0o644" }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'
     ansible.builtin.include_role:

--- a/roles/repo_remi/tasks/main.yml
+++ b/roles/repo_remi/tasks/main.yml
@@ -19,7 +19,8 @@
       dest: '/etc/yum.repos.d/{{ item | basename }}'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_remi__basic_auth_login | default({}) | length > 0 else "0o644" }}'
     loop: '{{ __repo_remi__repo_files }}'
 
   - name: 'Remove rpmnew / rpmsave (and Debian equivalents)'

--- a/roles/repo_rpmfusion/tasks/main.yml
+++ b/roles/repo_rpmfusion/tasks/main.yml
@@ -7,7 +7,8 @@
       dest: '/{{ item }}'
       owner: 'root'
       group: 'root'
-      mode: 0o644
+      # 0600 while the file carries the mirror credentials
+      mode: '{{ "0o600" if repo_rpmfusion__basic_auth_login | default({}) | length > 0 else "0o644" }}'
     loop:
       - 'etc/yum.repos.d/rpmfusion-free-updates-testing.repo'
       - 'etc/yum.repos.d/rpmfusion-free-updates.repo'


### PR DESCRIPTION
25 template tasks across 21 `repo_*` roles render a mirror password into a repository file below `/etc/yum.repos.d` or `/etc/zypp/repos.d` and left it world-readable at `0644`, so every local account on the host could read the credentials of our package mirror.

The mode is now conditional on the role's `basic_auth_login` instead of a flat `0600`:

```yaml
      # 0600 while the file carries the mirror credentials
      mode: '{{ "0o600" if repo_grafana__basic_auth_login | default({}) | length > 0 else "0o644" }}'
```

## Why conditional and not simply 0600

`0600` has a price that is easy to miss. An unprivileged `dnf` skips a repository file it cannot read without a single word on stderr, so `dnf list` and `dnf repolist` stop showing those repositories and give no hint why. Measured on Rocky Linux 9.7 with `dnf-4.14.0-31.el9` and `libdnf-0.69.0-16.el9`, `/etc/yum.repos.d/rocky.repo` set to `0600`:

```text
dnf repolist as root    -> appstream, baseos, extras
dnf repolist as tester  -> extras only, stderr empty, exit code 0
dnf list bash as tester -> installed version only, no available version
```

That is worth paying where there is a secret to protect, and not worth paying on the majority of hosts, which use the vendor repositories without authentication. A repository file without credentials therefore keeps `0644`.

## Why the skip is silent

Reading `dnf` alone suggests the opposite, because `dnf/conf/read.py` does have a warning path:

```python
try:
    parser.read(repofn)
except RuntimeError as e:
    raise dnf.exceptions.ConfigError(...)   # -> "Warning: failed loading '%s', skipping."
except IOError as e:
    logger.warning(e)
```

The exception never gets that far. `libdnf` throws `IniParser::CantOpenFile` on `EACCES`, `ConfigParser::read` re-throws it as `ConfigParser::CantOpenFile`, and the SWIG layer maps it to a Python `IOError`. But `bindings/swig/conf.i` then replaces `ConfigParser.read` with a Python shim that swallows exactly that:

```python
try:
    self.readFileName(fname)
    parsedFNames.append(fname)
except IOError:
    pass
```

The parser is left with zero sections, `dnf` iterates zero repositories, and nothing is logged. Calling the binding directly confirms it, as an unprivileged user:

```text
/etc/yum.repos.d/rocky.repo (0600):     ConfigParser.read OK, sections=[]
/etc/yum.repos.d/does-not-exist.repo:   ConfigParser.read OK, sections=[]
```

Rocky Linux 10.1 still ships `dnf` 4 with `libdnf`, so this holds across RHEL 8, 9 and 10.

## dnf5 behaves differently

On Fedora 43 with `dnf5-5.2.18` an unreadable repository file is fatal rather than silent:

```text
runuser -u tester -- dnf repolist
exit code 1, stdout empty
Unable to access configuration file "/etc/yum.repos.d/fedora.repo"
 cannot open file: (13) - Permission denied
```

A single `0600` repository file breaks every unprivileged `dnf` call on the host, not just the one repository. No `repo_*` role lists Fedora in `COMPATIBILITY.md`, so nothing here is affected today, but the conditional mode matters more once `dnf5` reaches RHEL, not less.

## Why the expression looks the way it does

The obvious spelling is silently wrong, so both forms were measured with `ansible-playbook` rather than assumed:

```text
mode: "{{ 0o600 if ... }}"      -> 644   (the integer is rendered and never applied)
mode: '{{ "0o600" if ... }}'    -> 600   credential set
                                -> 644   variable undefined
                                -> 644   variable defined but empty
```

## Notes for the reviewer

* GPG key tasks keep `0644`, only the repository files change.
* The Debian side needs no change: the apt sources templates carry no inline credentials.
* Quoting, `| length > 0` and the `0o` octal notation follow CONTRIBUTING; the one existing precedent for a mode inside Jinja is `roles/nfs_client`.
