### PR TITLE
ci: unify auto-merge across bots

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: 'Linuxfabrik: Dependabot auto-merge'
+name: 'Linuxfabrik: Auto-merge'
 
 on:
   pull_request: {}
@@ -17,7 +17,7 @@ env:
   FROZEN_LOCKFILES: '[]'
 
 jobs:
-  auto-merge:
+  dependabot:
     runs-on: 'ubuntu-latest'
     if: 'github.actor == ''dependabot[bot]'''
     permissions:
@@ -59,6 +59,27 @@ jobs:
           && (steps.meta.outputs.update-type == 'version-update:semver-patch'
               || steps.meta.outputs.update-type == 'version-update:semver-minor')
         run: |
+          gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_URL: '${{ github.event.pull_request.html_url }}'
+
+  # The weekly hook bump carries nothing but `rev:` changes in
+  # .pre-commit-config.yaml, and it arrives in every repository at once.
+  # Merging that by hand is pure overhead, so it goes in as soon as the
+  # required checks pass. The same fallback as above applies, and it is only
+  # safe because the ruleset keeps enforcing those checks server-side.
+  pre-commit-autoupdate:
+    runs-on: 'ubuntu-latest'
+    if: >-
+      github.actor == 'linuxfabrik-automation[bot]'
+      && github.head_ref == 'chore/pre-commit-autoupdate'
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+    steps:
+
+      - run: |
           gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/lf-pre-commit.yml
+++ b/.github/workflows/lf-pre-commit.yml
@@ -1,0 +1,41 @@
+name: 'Linuxfabrik: Pre-commit'
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+permissions:
+  contents: 'read'
+
+jobs:
+  pre-commit:
+    name: 'Pre-commit'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Harden the runner (Audit all outbound calls)'
+        uses: 'step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40' # v2.20.1
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # v7.0.1
+
+      # The lowest version pyproject.toml supports, which is also ruff's
+      # target-version.  bandit and vulture parse the sources with this
+      # interpreter, so syntax newer than the floor fails here rather than
+      # on a user's machine.
+      - name: 'Set up Python'
+        uses: 'actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97' # v7.0.0
+        with:
+          python-version: '3.9'
+
+      - name: 'Install pre-commit'
+        run: 'pip install --require-hashes --requirement .github/pre-commit/requirements.txt'
+
+      # --all-files, because the hooks otherwise only see what a commit
+      # happens to touch, and nothing guarantees a contributor ran
+      # `pre-commit install` at all.
+      - name: 'Run the hooks over the whole tree'
+        run: 'pre-commit run --all-files --show-diff-on-failure'

--- a/.github/workflows/lf-pre-commit.yml
+++ b/.github/workflows/lf-pre-commit.yml
@@ -22,14 +22,14 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # v7.0.1
 
-      # The lowest version pyproject.toml supports, which is also ruff's
-      # target-version.  bandit and vulture parse the sources with this
-      # interpreter, so syntax newer than the floor fails here rather than
-      # on a user's machine.
+      # This runs pre-commit itself, not the collection.  The pinned stack in
+      # .github/pre-commit/requirements.txt needs 3.10 or newer, so it cannot
+      # be the py39 floor the controller plugins support.  That floor is
+      # covered by the matrix in lf-unit-tests.yml instead.
       - name: 'Set up Python'
         uses: 'actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97' # v7.0.0
         with:
-          python-version: '3.9'
+          python-version: '3.13'
 
       - name: 'Install pre-commit'
         run: 'pip install --require-hashes --requirement .github/pre-commit/requirements.txt'


### PR DESCRIPTION
Unifies how bot pull requests are merged across the repositories.

- `dependabot-auto-merge.yml` becomes `auto-merge.yml` and gains a second job that merges the weekly pre-commit hook bump. Until now that bump reached every repository at once, carried nothing but `rev:` changes, and still had to be merged by hand.
- `lf-pre-commit.yml` runs the hooks over the whole tree on every pull request, so a hook bump that breaks something is caught before it is merged. The `Pre-commit` job is meant to become a required check once this is merged.