### PR TITLE
fix(ci): build the EE image without the registry prefix

### DIFF
--- a/.github/workflows/lf-build.yml
+++ b/.github/workflows/lf-build.yml
@@ -91,17 +91,23 @@ jobs:
             --server https://galaxy.ansible.com \
             --api-key "$ANSIBLE_GALAXY_TOKEN"
 
+      # Tagged without the registry prefix, so podman stores the image under
+      # localhost/.  push-to-registry derives its push source from the bare
+      # `image` input and prefixes that with localhost/, while its existence
+      # check uses the bare name and still resolves a `ghcr.io/...` image.
+      # A registry-prefixed local name therefore passes the check and fails
+      # the push.  Verified with podman 5.8.4 on Fedora 44.
       - name: 'Build Execution Environment'
         run: |
           ansible-builder build \
-            --tag 'ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/lfops_ee:${{ env.TAG1 }}' \
+            --tag '${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/lfops_ee:${{ env.TAG1 }}' \
             -vvv
 
       - name: 'Re-tag the image'
         run: |
           podman tag \
-            'ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/lfops_ee:${{ env.TAG1 }}' \
-            'ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/lfops_ee:${{ env.TAG2 }}'
+            '${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/lfops_ee:${{ env.TAG1 }}' \
+            '${{ env.GITHUB_REPOSITORY_OWNER_LOWERCASE }}/lfops_ee:${{ env.TAG2 }}'
 
       - name: 'Push to GitHub Container Registry'
         id: 'push-to-ghcr'


### PR DESCRIPTION
Prepares `lf-build.yml` for `redhat-actions/push-to-registry` v3, which #319 wants to bump to.

v3 prefixes its push source with `localhost/` (upstream issue #66, `src/index.ts:328`), while its existence check keeps using the bare `image` input, which podman also resolves to a local `ghcr.io/...` image. The EE was built as `ghcr.io/<owner>/lfops_ee`, so under v3 the check would pass and the push would fail with `image not known`. That failure would only surface during a release, after the collection is already on Galaxy.

Building the image unqualified stores it under `localhost/`, where both the check and the push find it.

Verified with podman 5.8.4 on Fedora 44:

- `podman image exists <owner>/lfops_ee:<tag>` → rc=0 for both tags
- `podman push localhost/<owner>/lfops_ee:<tag>` → rc=0 for both tags, the v3 path
- `podman push <owner>/lfops_ee:<tag>` → rc=0, the v2.8 path, so this works with the currently pinned version too

`ansible-builder` passes `--tag` straight to `podman build -t` without normalising it (`src/ansible_builder/main.py:196`).