### PR TITLE
fix(roles/system_update, roles/schedule_reboot): report only what a run actually did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **role:system_update**: A host with nothing to update no longer sends a "System updated without Reboot" mail on every update day.
+* **role:system_update**: The update mail and the reboot request describe the packages the run just changed instead of those of an earlier run.
 * **playbook:icingaweb2, playbook:setup_icinga2_master, role:icingaweb2** update `icingaweb2` dependent vars to ensure php.ini value `post_max_size` > `upload_max_filesize` by default.
 * **role:monitoring_plugins**: A source install installs the dependencies of the Linuxfabrik library, so checks that speak HTTP, MySQL, SMB or WinRM no longer report `Python module "httpx" is not installed` and its equivalents.
 * **role:monitoring_plugins**: A source install deploys the event plugins, which only the rpm/deb package used to ship.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **role:system_update**: A host with nothing to update no longer sends a "System updated without Reboot" mail on every update day.
 * **role:system_update**: The update mail and the reboot request describe the packages the run just changed instead of those of an earlier run.
+* **role:system_update**: The AIDE database is only refreshed when the update changed packages and the AIDE check was passing beforehand, so a host that was already reporting changes keeps reporting them instead of having them accepted as the new baseline.
+* **role:system_update**: On Debian the AIDE database is refreshed after the upgrade instead of before it, so the next check no longer flags every file the upgrade touched.
 * **playbook:icingaweb2, playbook:setup_icinga2_master, role:icingaweb2** update `icingaweb2` dependent vars to ensure php.ini value `post_max_size` > `upload_max_filesize` by default.
 * **role:monitoring_plugins**: A source install installs the dependencies of the Linuxfabrik library, so checks that speak HTTP, MySQL, SMB or WinRM no longer report `Python module "httpx" is not installed` and its equivalents.
 * **role:monitoring_plugins**: A source install deploys the event plugins, which only the rpm/deb package used to ship.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **role:system_update**: The AIDE database is only refreshed when the update changed packages and the AIDE check was passing beforehand, so a host that was already reporting changes keeps reporting them instead of having them accepted as the new baseline.
 * **role:system_update**: The AIDE database is refreshed after the update rather than before it, on Debian and Ubuntu as well as on RHEL, so the next check no longer flags every file the update touched.
 * **role:system_update**: A failed update on Debian is reported and stops the run, instead of being followed by a success mail or by the reboot of a half-configured host.
+* **role:schedule_reboot**: The role no longer aborts while deploying its reboot helper on Debian 12 and older and on Ubuntu 24.04 and older. Roles that pull it in, `system_update` among them, were unusable on those releases as well.
 * **playbook:icingaweb2, playbook:setup_icinga2_master, role:icingaweb2** update `icingaweb2` dependent vars to ensure php.ini value `post_max_size` > `upload_max_filesize` by default.
 * **role:monitoring_plugins**: A source install installs the dependencies of the Linuxfabrik library, so checks that speak HTTP, MySQL, SMB or WinRM no longer report `Python module "httpx" is not installed` and its equivalents.
 * **role:monitoring_plugins**: A source install deploys the event plugins, which only the rpm/deb package used to ship.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **role:system_update**: The update mail and the reboot request describe the packages the run just changed instead of those of an earlier run.
 * **role:system_update**: The AIDE database is only refreshed when the update changed packages and the AIDE check was passing beforehand, so a host that was already reporting changes keeps reporting them instead of having them accepted as the new baseline.
 * **role:system_update**: On Debian the AIDE database is refreshed after the upgrade instead of before it, so the next check no longer flags every file the upgrade touched.
+* **role:system_update**: A failed update on Debian is reported and stops the run, instead of being followed by a success mail or by the reboot of a half-configured host.
 * **playbook:icingaweb2, playbook:setup_icinga2_master, role:icingaweb2** update `icingaweb2` dependent vars to ensure php.ini value `post_max_size` > `upload_max_filesize` by default.
 * **role:monitoring_plugins**: A source install installs the dependencies of the Linuxfabrik library, so checks that speak HTTP, MySQL, SMB or WinRM no longer report `Python module "httpx" is not installed` and its equivalents.
 * **role:monitoring_plugins**: A source install deploys the event plugins, which only the rpm/deb package used to ship.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **role:system_update**: A requested reboot names the core packages or the running services that ask for it, instead of only listing what the run changed.
 * **role:system_update**: A host with nothing to update no longer sends a "System updated without Reboot" mail on every update day.
 * **role:system_update**: The update mail and the reboot request describe the packages the run just changed instead of those of an earlier run.
 * **role:system_update**: The AIDE database is only refreshed when the update changed packages and the AIDE check was passing beforehand, so a host that was already reporting changes keeps reporting them instead of having them accepted as the new baseline.
-* **role:system_update**: On Debian the AIDE database is refreshed after the upgrade instead of before it, so the next check no longer flags every file the upgrade touched.
+* **role:system_update**: The AIDE database is refreshed after the update rather than before it, on Debian and Ubuntu as well as on RHEL, so the next check no longer flags every file the update touched.
 * **role:system_update**: A failed update on Debian is reported and stops the run, instead of being followed by a success mail or by the reboot of a half-configured host.
 * **playbook:icingaweb2, playbook:setup_icinga2_master, role:icingaweb2** update `icingaweb2` dependent vars to ensure php.ini value `post_max_size` > `upload_max_filesize` by default.
 * **role:monitoring_plugins**: A source install installs the dependencies of the Linuxfabrik library, so checks that speak HTTP, MySQL, SMB or WinRM no longer report `Python module "httpx" is not installed` and its equivalents.

--- a/extensions/molecule/schedule_reboot/reboot/inventory/group_vars/systems_under_test.yml
+++ b/extensions/molecule/schedule_reboot/reboot/inventory/group_vars/systems_under_test.yml
@@ -7,6 +7,10 @@ postfix__relayhost: 'mail.example.com'
 
 schedule_reboot__reboot_time__group_var: '03:00'
 
+# A prefix carrying brackets. Brackets are RFC 5322 specials, so the notification's From
+# display name has to be quoted for them; verify.yml asserts on the delivered header.
+schedule_reboot__mail_subject_prefix: '[molecule] '
+
 # reboot immediately on --now: this scenario asserts the reboot via a boot_id change
 # after wait_for_connection, so the default grace sleep would keep the host up past
 # the reconnect and make the check flap. The grace period itself is not under test here.

--- a/extensions/molecule/schedule_reboot/reboot/verify.yml
+++ b/extensions/molecule/schedule_reboot/reboot/verify.yml
@@ -1,5 +1,6 @@
 # Destructive verify: actually reboot the host through the CLI and confirm it
-# came back (boot_id changed) with an empty spool (tmpfs cleared on reboot).
+# came back (boot_id changed) with an empty spool (tmpfs cleared on reboot), and
+# that the notification do-reboot sent on the way down is a well-formed message.
 - name: 'Verify schedule_reboot performs a real reboot'
   hosts: 'systems_under_test'
   gather_facts: false
@@ -42,3 +43,29 @@
     - name: 'Assert the spool is empty (tmpfs cleared by the reboot)'
       ansible.builtin.assert:
         that: '__molecule__spool_after_result["matched"] == 0'
+
+    # do-reboot mails the administrators before it goes down. postfix counts localhost
+    # among its own destinations, so root@localhost is delivered into the root mailbox
+    # instead of leaving via the (unreachable) relayhost. The grace period is 0 in this
+    # scenario, so the message usually only leaves the queue after the reboot - hence
+    # the retries.
+    - name: 'stat /var/mail/root'
+      ansible.builtin.stat:
+        path: '/var/mail/root'
+      register: '__molecule__root_mailbox_stat_result'
+      until: '__molecule__root_mailbox_stat_result["stat"]["exists"]'
+      retries: 12
+      delay: 5
+
+    - name: 'slurp /var/mail/root'
+      ansible.builtin.slurp:
+        src: '/var/mail/root'
+      register: '__molecule__root_mailbox_result'
+
+    # The bracketed prefix from group_vars must arrive as a quoted display name. Without
+    # the quoting a strict parser drops the whole address, not just the name.
+    - name: 'Assert the reboot notification carries a quoted From display name'
+      ansible.builtin.assert:
+        that: '__molecule__expected_from in (__molecule__root_mailbox_result["content"] | ansible.builtin.b64decode)'
+      vars:
+        __molecule__expected_from: "From: \"[molecule] "

--- a/extensions/molecule/system_update/verify.yml
+++ b/extensions/molecule/system_update/verify.yml
@@ -111,9 +111,41 @@
     # and send no "System updated" mail. Running a full update per VM is the expensive
     # part of this scenario, but it is the only way to reach a host that is genuinely up
     # to date, which is the state the quiet path only ever happens on.
+    # This run installs everything the cloud image has pending, systemd included, and the systemd
+    # RPM re-execs the running init from its own scriptlet ("systemctl daemon-reexec"). That tears
+    # down the D-Bus connection this blocking call is waiting on, so systemctl exits 1 with
+    # "Failed to wait for response: Connection reset by peer" while the unit itself carries on and
+    # finishes normally. Tolerate exactly that error and wait for the unit instead, otherwise the
+    # scenario fails on every RedHat-family host for a reason unrelated to the code under test.
+    # Verified against systemd 252-67 on Rocky 9.
     - name: 'systemctl start update-and-reboot.service (first run, applies all pending updates)' # noqa command-instead-of-module (need to run the oneshot and read its Result)
       ansible.builtin.command: 'systemctl start update-and-reboot.service'
+      register: '__molecule__update_first_start_result'
       changed_when: false
+      failed_when:
+        - '__molecule__update_first_start_result["rc"] != 0'
+        - '"D-Bus connection terminated" not in __molecule__update_first_start_result["stderr"]'
+
+    # systemctl has returned, so the job is queued either way: if the call survived, the oneshot
+    # has already finished and this polls once; if it was cut off, the unit is still activating.
+    - name: 'Wait for the first run to finish' # noqa command-instead-of-module (no module polls a oneshot to completion)
+      ansible.builtin.command: 'systemctl show --property=ActiveState --value update-and-reboot.service'
+      register: '__molecule__update_first_state_result'
+      until: '__molecule__update_first_state_result["stdout"] != "activating"'
+      retries: 90
+      delay: 10
+      changed_when: false
+
+    - name: 'systemctl show --property=Result update-and-reboot.service (first run)' # noqa command-instead-of-module (no module reads a oneshot Result)
+      ansible.builtin.command: 'systemctl show --property=Result --value update-and-reboot.service'
+      register: '__molecule__update_first_result'
+      changed_when: false
+
+    # Guards the tolerated D-Bus error above: the run still has to have succeeded, it just may not
+    # have been able to say so over D-Bus.
+    - name: 'Assert the first run completed successfully'
+      ansible.builtin.assert:
+        that: '__molecule__update_first_result["stdout"] == "success"'
 
     # Generous timeout: the first run may have pulled a new kernel, and the first boot
     # into it takes longer than the module's 600s default allows for on a slow host.

--- a/extensions/molecule/system_update/verify.yml
+++ b/extensions/molecule/system_update/verify.yml
@@ -3,7 +3,8 @@
 # which exercises the metadata refresh (with its transient-mirrorlist retry) before
 # any update; on Rocky the security lane exists and is a clean no-op without the
 # security repo; off Rocky the security lane is absent. sendmail (the transport the
-# scripts now use) is available.
+# scripts now use) is available. Finally the regular update lane itself runs twice,
+# so the second run lands on a host that is genuinely up to date and must stay quiet.
 #
 # gather_facts is on here because the security-lane checks branch on
 # ansible_facts["distribution"].
@@ -102,3 +103,79 @@
     - name: 'Assert sendmail is available for the update notifications'
       ansible.builtin.assert:
         that: '__molecule__sendmail_stat_result["stat"]["exists"]'
+
+    # The regular update lane, end to end and twice. The first run applies whatever the
+    # cloud image has pending, the reboot clears the pending-reboot state that run may
+    # have created, and the second run then finds nothing left to do. That second run is
+    # what is under test: it has to notice that no packages changed, request no reboot
+    # and send no "System updated" mail. Running a full update per VM is the expensive
+    # part of this scenario, but it is the only way to reach a host that is genuinely up
+    # to date, which is the state the quiet path only ever happens on.
+    - name: 'systemctl start update-and-reboot.service (first run, applies all pending updates)' # noqa command-instead-of-module (need to run the oneshot and read its Result)
+      ansible.builtin.command: 'systemctl start update-and-reboot.service'
+      changed_when: false
+
+    # Generous timeout: the first run may have pulled a new kernel, and the first boot
+    # into it takes longer than the module's 600s default allows for on a slow host.
+    - name: 'Reboot, so a reboot requested by the first run cannot mask the second'
+      ansible.builtin.reboot:
+        reboot_timeout: 900
+
+    - name: 'rm /var/mail/root, so the mailbox only holds what the second run sends'
+      ansible.builtin.file:
+        path: '/var/mail/root'
+        state: 'absent'
+
+    - name: 'systemctl start update-and-reboot.service (second run, nothing left to update)' # noqa command-instead-of-module (need to run the oneshot and read its Result)
+      ansible.builtin.command: 'systemctl start update-and-reboot.service'
+      changed_when: false
+
+    - name: 'systemctl show --property=Result update-and-reboot.service' # noqa command-instead-of-module (no module reads a oneshot Result)
+      ansible.builtin.command: 'systemctl show --property=Result --value update-and-reboot.service'
+      register: '__molecule__update_and_reboot_result'
+      changed_when: false
+
+    # --boot scopes this to the current boot, and the reboot above means the second run
+    # is the only invocation in it, so the first run's lines cannot satisfy the
+    # assertions below. Scoping by InvocationID would be the obvious alternative, but
+    # systemd keeps that in a cgroup xattr needing CAP_SYS_ADMIN, so it is empty in some
+    # environments; --boot works everywhere.
+    # Verified against systemd 239 (Rocky 8).
+    - name: 'journalctl --unit=update-and-reboot.service --boot (second run only)' # noqa command-instead-of-module (no module reads the journal)
+      ansible.builtin.command: 'journalctl --unit=update-and-reboot.service --boot --output=cat --no-pager'
+      register: '__molecule__update_and_reboot_journal_result'
+      changed_when: false
+
+    - name: 'stat /run/schedule-reboot/system_update'
+      ansible.builtin.stat:
+        path: '/run/schedule-reboot/system_update'
+      register: '__molecule__update_request_stat_result'
+
+    - name: 'Assert the second run saw no changes and requested no reboot'
+      ansible.builtin.assert:
+        that:
+          - '__molecule__update_and_reboot_result["stdout"] == "success"'
+          - '"No packages were changed in this run" in __molecule__update_and_reboot_journal_result["stdout"]'
+          - '"Nothing to report" in __molecule__update_and_reboot_journal_result["stdout"]'
+          - 'not __molecule__update_request_stat_result["stat"]["exists"]'
+
+    # The config-file stub notification may still mail about the *.rpmnew / *.dpkg-dist
+    # files the first run created, so assert on the subject instead of on an empty
+    # mailbox.
+    - name: 'stat /var/mail/root'
+      ansible.builtin.stat:
+        path: '/var/mail/root'
+      register: '__molecule__root_mailbox_stat_result'
+
+    - name: 'slurp /var/mail/root'
+      ansible.builtin.slurp:
+        src: '/var/mail/root'
+      register: '__molecule__root_mailbox_result'
+      when: '__molecule__root_mailbox_stat_result["stat"]["exists"]'
+
+    - name: 'Assert the second run sent no "System updated without Reboot" mail'
+      ansible.builtin.assert:
+        that: '__molecule__updated_subject not in (__molecule__root_mailbox_result["content"] | ansible.builtin.b64decode)'
+      vars:
+        __molecule__updated_subject: 'System updated without Reboot'
+      when: '__molecule__root_mailbox_stat_result["stat"]["exists"]'

--- a/roles/schedule_reboot/tasks/main.yml
+++ b/roles/schedule_reboot/tasks/main.yml
@@ -1,5 +1,18 @@
 - block:
 
+  # /usr/local/libexec is not part of every base layout: Debian ships it from trixie on and
+  # Ubuntu from 26.04 on, while the RedHat family has always had it. Without this the deploy
+  # below fails with "Destination directory /usr/local/libexec does not exist". root:root 0755
+  # is what the distributions that do ship it use, and matches /usr/local/{bin,sbin} everywhere.
+  # Verified against Debian 11, 12 and 13, Ubuntu 22.04 and 24.04, and Rocky 9.
+  - name: 'Ensure /usr/local/libexec exists'
+    ansible.builtin.file:
+      path: '/usr/local/libexec'
+      state: 'directory'
+      owner: 'root'
+      group: 'root'
+      mode: 0o755
+
   - name: 'Deploy /usr/local/libexec/do-reboot'
     ansible.builtin.template:
       backup: true

--- a/roles/schedule_reboot/templates/usr/local/libexec/do-reboot.j2
+++ b/roles/schedule_reboot/templates/usr/local/libexec/do-reboot.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026061001
+# 2026082501
 
 # The single reboot actor. Run by schedule-reboot.service (a timer at the reboot
 # window, ordered After= the update lanes) and by `schedule-reboot --now`. Reboots
@@ -24,7 +24,7 @@ send_msg () {
         printf 'Content-Type: text/plain; charset="utf-8"\n'
         printf 'Content-Transfer-Encoding: 8bit\n'
         printf '\n%s\n' "$body"
-    } | sendmail -oi -t -f "$SENDER"
+    } | sendmail -oi -t -f "$MAIL_FROM"
 {% if schedule_reboot__rocketchat_url is defined and schedule_reboot__rocketchat_url | length %}
     /usr/bin/curl --silent --output /dev/null --data-urlencode \
         "text=${subject}
@@ -37,7 +37,12 @@ send_msg () {
 }
 
 SUBJECT_PREFIX="{{ schedule_reboot__mail_subject_prefix }}{{ schedule_reboot__mail_subject_hostname }}"
-SENDER="$SUBJECT_PREFIX <{{ schedule_reboot__mail_from }}>"
+MAIL_FROM='{{ schedule_reboot__mail_from }}'
+# RFC 5322 permits only atoms in an unquoted display name. A subject prefix such as
+# "[schedule_reboot] " carries brackets, which are specials, and a strict parser then
+# drops the whole address rather than just the name. So quote the display name, escaping
+# any embedded backslash or double quote.
+SENDER="\"$(printf '%s' "$SUBJECT_PREFIX" | sed 's/[\\"]/\\&/g')\" <$MAIL_FROM>"
 RECIPIENTS="{{ schedule_reboot__mail_recipients | join(' ') }}"
 
 # no reboot requested -> nothing to do (the common case on most days).

--- a/roles/system_update/README.md
+++ b/roles/system_update/README.md
@@ -11,6 +11,7 @@ Reboots are not performed by the update scripts themselves. They are delegated t
 ## How the Role Behaves
 
 * **Updates run at the reboot window.** The regular lane (weekly) and the Rocky security lane (daily) both run at the maintenance window defined by `schedule_reboot__reboot_time__*` (the [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot) role). When an update needs a reboot it drops a request into that role's spool; the update unit is ordered before the reboot actor, so the reboot waits for the update to finish before it runs.
+* **The regular lane only reports when it actually changed something.** On an update day where nothing was pending, it still checks whether a reboot is outstanding, but sends no "System updated without Reboot" mail. The mail it does send lists the packages of that run, not of an earlier one.
 * **The security lane is enabled by default, but a no-op without the `security` repository.** That repository is provided by the [repo_baseos](https://github.com/Linuxfabrik/lfops/tree/main/roles/repo_baseos) role. On hosts where it is not present, the security lane installs nothing and requests no reboot. Turn the lane off entirely with `system_update__security_enabled: false`.
 
 

--- a/roles/system_update/README.md
+++ b/roles/system_update/README.md
@@ -13,6 +13,8 @@ Reboots are not performed by the update scripts themselves. They are delegated t
 * **Updates run at the reboot window.** The regular lane (weekly) and the Rocky security lane (daily) both run at the maintenance window defined by `schedule_reboot__reboot_time__*` (the [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot) role). When an update needs a reboot it drops a request into that role's spool; the update unit is ordered before the reboot actor, so the reboot waits for the update to finish before it runs.
 * **The regular lane only reports when it actually changed something.** On an update day where nothing was pending, it still checks whether a reboot is outstanding, but sends no "System updated without Reboot" mail. The mail it does send lists the packages of that run, not of an earlier one.
 * **The security lane is enabled by default, but a no-op without the `security` repository.** That repository is provided by the [repo_baseos](https://github.com/Linuxfabrik/lfops/tree/main/roles/repo_baseos) role. On hosts where it is not present, the security lane installs nothing and requests no reboot. Turn the lane off entirely with `system_update__security_enabled: false`.
+* **A failed update stops the run.** A metadata refresh or an upgrade that exits non-zero sends a "System update failed" mail with the error output and ends the run, on both families. Nothing downstream happens: no AIDE re-baseline, no reboot request, and no success mail for a host that is left half-configured.
+* **AIDE is re-baselined only when the check was clean beforehand.** If the host runs an AIDE check lane and the update changed packages, the regular lane refreshes the AIDE database afterwards and restarts the check, so the next check does not flag every file the update touched. If the check was already reporting changes when the update started, the database is left untouched and the log is kept at `/var/log/aide/aide.log-pre-system-update`: drift that predates the update, an intrusion included, is never accepted as the new baseline.
 
 
 ## Dependent Roles
@@ -23,13 +25,6 @@ Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/RE
 * Optional: postfix provides the `sendmail` interface and mail relay used for the notifications (role: [linuxfabrik.lfops.postfix](https://github.com/Linuxfabrik/lfops/tree/main/roles/postfix)).
 * The reboot mechanism must be present (role: [linuxfabrik.lfops.schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot)). It owns the reboot window (`schedule_reboot__reboot_time__*`) and performs the reboot an update requests.
 * Optional: yum-utils is installed on RHEL (role: [linuxfabrik.lfops.yum_utils](https://github.com/Linuxfabrik/lfops/tree/main/roles/yum_utils)).
-
-
-## Requirements
-
-Manual steps:
-
-* On Debian, install needrestart by running the [apps](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/apps.yml) playbook (role: [linuxfabrik.lfops.apps](https://github.com/Linuxfabrik/lfops/tree/main/roles/apps)).
 
 
 ## Tags
@@ -170,9 +165,7 @@ system_update__pre_update_code: |-
   check_dns() {
     local DNS_SERVER=$1
     if ! dig @$DNS_SERVER linuxfabrik.ch +short > /dev/null; then
-        SUBJECT="$SUBJECT_PREFIX - System update failed"
-        MSGBODY="DNS Server $DNS_SERVER failed to respond. Aborting update."
-        send_msg
+        send_msg "$SUBJECT_PREFIX - System update failed" "DNS Server $DNS_SERVER failed to respond. Aborting update."
         exit 1
     fi
   }

--- a/roles/system_update/templates/usr/local/libexec/notify-and-schedule.j2
+++ b/roles/system_update/templates/usr/local/libexec/notify-and-schedule.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026070301
+# 2026082501
 
 # Check for available updates and notify the administrators. This is informational
 # only: the update is applied later by update-and-reboot.service at the maintenance
@@ -25,7 +25,7 @@ send_msg () {
         printf 'Content-Type: text/plain; charset="utf-8"\n'
         printf 'Content-Transfer-Encoding: 8bit\n'
         printf '\n%s\n' "$body"
-    } | sendmail -oi -t -f "$SENDER"
+    } | sendmail -oi -t -f "$MAIL_FROM"
 {% if system_update__rocketchat_url is defined and system_update__rocketchat_url | length %}
     /usr/bin/curl --silent --output /dev/null --data-urlencode \
         "text=${subject}
@@ -54,7 +54,12 @@ makecache_with_retry () {
 {% endif %}
 
 SUBJECT_PREFIX="{{ system_update__mail_subject_prefix }}{{ system_update__mail_subject_hostname }}"
-SENDER="$SUBJECT_PREFIX <{{ system_update__mail_from }}>"
+MAIL_FROM='{{ system_update__mail_from }}'
+# RFC 5322 permits only atoms in an unquoted display name. A subject prefix such as
+# "[system_update] " carries brackets, which are specials, and a strict parser then
+# drops the whole address rather than just the name. So quote the display name, escaping
+# any embedded backslash or double quote.
+SENDER="\"$(printf '%s' "$SUBJECT_PREFIX" | sed 's/[\\"]/\\&/g')\" <$MAIL_FROM>"
 RECIPIENTS="{{ system_update__mail_recipients_updates | join(' ') }}"
 
 # the next scheduled run of the regular update lane, so the admin sees when the

--- a/roles/system_update/templates/usr/local/sbin/security-update.j2
+++ b/roles/system_update/templates/usr/local/sbin/security-update.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026070301
+# 2026082501
 
 # Apply Rocky Linux security hot-fixes from the dedicated `security` repository
 # only, then request a reboot if one is needed by dropping a file into the
@@ -54,6 +54,18 @@ makecache_with_retry () {
     return 1
 }
 
+last_txn_id () {
+    # dnf lists its history newest first, with the transaction id in the first column;
+    # neither the header nor the separator line starts with a digit. Comparing the id
+    # from before and after the transaction is what tells us whether this run changed
+    # anything at all: a bare `yum history info` always reports the last transaction,
+    # even the one the weekly lane made minutes earlier on a day where both run. A host
+    # whose history is still empty yields an empty id on both sides, which compares
+    # equal and is correct.
+    # Verified against dnf 4.7 (Rocky 8), 4.14 (Rocky 9) and 4.20 (Rocky 10).
+    yum history list 2> /dev/null | awk '$1 ~ /^[0-9]+$/ { print $1; exit }'
+}
+
 SUBJECT_PREFIX="{{ system_update__mail_subject_prefix }}{{ system_update__mail_subject_hostname }}"
 SENDER="$SUBJECT_PREFIX <{{ system_update__mail_from }}>"
 RECIPIENTS="{{ system_update__mail_recipients_updates | join(' ') }}"
@@ -103,10 +115,24 @@ fi
 # keeps this lane separate from the regular (weekly) update lane and from the frozen
 # mirror snapshot.
 log "Applying security hot-fixes from: $REPOS"
+TXN_BEFORE=$(last_txn_id)
 if ! yum --disablerepo="*" --enablerepo="$REPOS" -y upgrade 1> /tmp/security-update 2> /tmp/security-update-stderr; then
     log "Security update failed; see /tmp/security-update-stderr"
     send_msg "$SUBJECT_PREFIX - Security update failed" "$(</tmp/security-update-stderr)"
     exit 1
+fi
+
+# check-update having found something does not guarantee a transaction: the package can
+# be gone from the repo by now, held by a versionlock, or unsatisfiable, in which case
+# the upgrade above exits 0 having done nothing.
+TXN_AFTER=$(last_txn_id)
+if [ "$TXN_AFTER" = "$TXN_BEFORE" ]; then
+    UPDATED=0
+    TXN_REPORT='No packages were changed in this run.'
+    log "Nothing was installed after all"
+else
+    UPDATED=1
+    TXN_REPORT=$(yum history info "$TXN_AFTER")
 fi
 
 # request a reboot if a core component (kernel, glibc, ...) needs it, or if running
@@ -118,7 +144,14 @@ needs-restarting 2> /dev/null > /tmp/security-needs-restarting
 if [ "$reboothint_rc" -eq 1 ] || [ -s /tmp/security-needs-restarting ]; then
     log "Reboot required after security update; requesting reboot via the spool"
     # request a reboot; do-reboot sends the single notification at reboot time
-    yum history info > /run/schedule-reboot/security_update
+    printf '%s\n' "$TXN_REPORT" > /run/schedule-reboot/security_update
+    exit 0
+fi
+
+# an upgrade that installed nothing has nothing to report, the same way the check above
+# stays quiet when the repo has nothing pending.
+if [ "$UPDATED" -eq 0 ]; then
+    log "Nothing to report"
     exit 0
 fi
 

--- a/roles/system_update/templates/usr/local/sbin/security-update.j2
+++ b/roles/system_update/templates/usr/local/sbin/security-update.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026082502
+# 2026082601
 
 # Apply Rocky Linux security hot-fixes from the dedicated `security` repository
 # only, then request a reboot if one is needed by dropping a file into the
@@ -75,6 +75,10 @@ MAIL_FROM='{{ system_update__mail_from }}'
 SENDER="\"$(printf '%s' "$SUBJECT_PREFIX" | sed 's/[\\"]/\\&/g')\" <$MAIL_FROM>"
 RECIPIENTS="{{ system_update__mail_recipients_updates | join(' ') }}"
 
+# set to 1 once we know that the transaction actually changed packages. gates the
+# closing notification.
+UPDATED=0
+
 # the reboot-request spool is owned and created by the schedule_reboot role (tmpfiles.d)
 
 log "Starting security update run"
@@ -85,7 +89,7 @@ log "Starting security update run"
 # where the repo is absent or was opted out via repo_baseos__security_repo_enabled.
 have_repo=0
 for repo in {{ system_update__security_repos | join(' ') }}; do
-    if dnf repolist --enabled 2> /dev/null | awk 'NR > 1 { print $1 }' | grep -qxF "$repo"; then
+    if dnf repolist --enabled 2> /dev/null | awk 'NR > 1 { print $1 }' | grep --quiet --line-regexp --fixed-strings "$repo"; then
         have_repo=1
     fi
 done
@@ -134,7 +138,7 @@ TXN_AFTER=$(last_txn_id)
 if [ "$TXN_AFTER" = "$TXN_BEFORE" ]; then
     UPDATED=0
     TXN_REPORT='No packages were changed in this run.'
-    log "Nothing was installed after all"
+    log "No packages were changed in this run"
 else
     UPDATED=1
     TXN_REPORT=$(yum history info "$TXN_AFTER")
@@ -142,14 +146,22 @@ fi
 
 # request a reboot if a core component (kernel, glibc, ...) needs it, or if running
 # services still use the pre-update libraries.
-needs-restarting --reboothint &> /dev/null
+needs-restarting --reboothint > /tmp/security-reboothint 2>&1
 reboothint_rc=$?
 needs-restarting 2> /dev/null > /tmp/security-needs-restarting
 
 if [ "$reboothint_rc" -eq 1 ] || [ -s /tmp/security-needs-restarting ]; then
     log "Reboot required after security update; requesting reboot via the spool"
-    # request a reboot; do-reboot sends the single notification at reboot time
-    printf '%s\n' "$TXN_REPORT" > /run/schedule-reboot/security_update
+    # request a reboot; do-reboot sends the single notification at reboot time. keep
+    # whichever check fired: the hint names the core packages, the list the services
+    # still on the pre-update libraries. Without them a reboot carried over from an
+    # earlier run arrives with nothing but "No packages were changed in this run.".
+    # Verified against dnf-utils on Rocky 9.
+    {
+        [ "$reboothint_rc" -eq 1 ] && cat /tmp/security-reboothint
+        [ -s /tmp/security-needs-restarting ] && cat /tmp/security-needs-restarting
+        printf '%s\n' "$TXN_REPORT"
+    } > /run/schedule-reboot/security_update
     exit 0
 fi
 

--- a/roles/system_update/templates/usr/local/sbin/security-update.j2
+++ b/roles/system_update/templates/usr/local/sbin/security-update.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026082501
+# 2026082502
 
 # Apply Rocky Linux security hot-fixes from the dedicated `security` repository
 # only, then request a reboot if one is needed by dropping a file into the
@@ -28,7 +28,7 @@ send_msg () {
         printf 'Content-Type: text/plain; charset="utf-8"\n'
         printf 'Content-Transfer-Encoding: 8bit\n'
         printf '\n%s\n' "$body"
-    } | sendmail -oi -t -f "$SENDER"
+    } | sendmail -oi -t -f "$MAIL_FROM"
 {% if system_update__rocketchat_url is defined and system_update__rocketchat_url | length %}
     /usr/bin/curl --silent --output /dev/null --data-urlencode \
         "text=${subject}
@@ -67,7 +67,12 @@ last_txn_id () {
 }
 
 SUBJECT_PREFIX="{{ system_update__mail_subject_prefix }}{{ system_update__mail_subject_hostname }}"
-SENDER="$SUBJECT_PREFIX <{{ system_update__mail_from }}>"
+MAIL_FROM='{{ system_update__mail_from }}'
+# RFC 5322 permits only atoms in an unquoted display name. A subject prefix such as
+# "[system_update] " carries brackets, which are specials, and a strict parser then
+# drops the whole address rather than just the name. So quote the display name, escaping
+# any embedded backslash or double quote.
+SENDER="\"$(printf '%s' "$SUBJECT_PREFIX" | sed 's/[\\"]/\\&/g')\" <$MAIL_FROM>"
 RECIPIENTS="{{ system_update__mail_recipients_updates | join(' ') }}"
 
 # the reboot-request spool is owned and created by the schedule_reboot role (tmpfiles.d)

--- a/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
+++ b/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026082502
+# 2026082503
 
 # Apply all available updates, then request a reboot if one is needed by dropping a
 # file into the /run/schedule-reboot spool. This script never reboots itself; the
@@ -136,9 +136,29 @@ fi
 {% endif %}
 
 {% if ansible_facts['os_family'] == 'Debian' %}
-apt-get update {{ system_update__cache_only | bool | ternary("--no-download", "") }} 1> /dev/null
+# apt-get update exits 0 when a mirror merely fails to answer, printing a `W: Failed to
+# fetch` warning and carrying on with the old lists; it only reports a non-zero status
+# for hard errors such as an unreadable sources list. So this catches a broken
+# configuration, not a mirror outage, unlike the retry loop of the RedHat lane.
+# Verified against apt 2.6 on Debian 12.
+if ! apt-get update {{ system_update__cache_only | bool | ternary("--no-download", "") }} 1> /dev/null 2> /tmp/system-update-stderr; then
+    log "Metadata refresh failed; see /tmp/system-update-stderr"
+    send_msg "$SUBJECT_PREFIX - System update failed" "$(</tmp/system-update-stderr)"
+    exit 1
+fi
+# keep those warnings in the journal, since they are the only trace of a mirror outage.
+[ -s /tmp/system-update-stderr ] && log "$(</tmp/system-update-stderr)"
+
 export DEBIAN_FRONTEND=noninteractive
-yes '' | apt-get -y -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" --with-new-pkgs upgrade > /tmp/update_output
+# the exit status of the pipeline is apt-get's own; `yes` only feeds it. A failing
+# maintainer script surfaces here as exit 100, with the detail split over both streams:
+# the package names on stdout, `E: Sub-process ... returned an error code` on stderr.
+# Verified against apt 2.6 on Debian 12.
+if ! yes '' | apt-get -y -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" --with-new-pkgs upgrade > /tmp/update_output 2> /tmp/system-update-stderr; then
+    log "System update failed; see /tmp/system-update-stderr"
+    send_msg "$SUBJECT_PREFIX - System update failed" "$(cat /tmp/system-update-stderr /tmp/update_output)"
+    exit 1
+fi
 
 # apt closes every run with a summary line; LC_ALL=C above keeps its wording stable.
 # only the first three counters are matched, so a run that changed nothing still counts

--- a/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
+++ b/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026070301
+# 2026082501
 
 # Apply all available updates, then request a reboot if one is needed by dropping a
 # file into the /run/schedule-reboot spool. This script never reboots itself; the
@@ -57,12 +57,27 @@ makecache_with_retry () {
     done
     return 1
 }
+
+last_txn_id () {
+    # dnf lists its history newest first, with the transaction id in the first column;
+    # neither the header nor the separator line starts with a digit. Comparing the id
+    # from before and after the transaction is what tells us whether this run changed
+    # anything at all: a bare `yum history info` always reports the last transaction,
+    # even one from a previous maintenance window. A host whose history is still empty
+    # yields an empty id on both sides, which compares equal and is correct.
+    # Verified against dnf 4.7 (Rocky 8), 4.14 (Rocky 9) and 4.20 (Rocky 10).
+    yum history list 2> /dev/null | awk '$1 ~ /^[0-9]+$/ { print $1; exit }'
+}
 {% endif %}
 
 SUBJECT_PREFIX="{{ system_update__mail_subject_prefix }}{{ system_update__mail_subject_hostname }}"
 SENDER="$SUBJECT_PREFIX <{{ system_update__mail_from }}>"
 RECIPIENTS="{{ system_update__mail_recipients_updates | join(' ' ) }}"
 RECIPIENTS_NEW_CONFIGFILES="{{ system_update__mail_recipients_new_configfiles | join(' ' ) }}"
+
+# set to 1 by the distribution-specific block below once it knows that the transaction
+# actually changed packages. gates the closing notification.
+UPDATED=0
 
 # the reboot-request spool is owned and created by the schedule_reboot role (tmpfiles.d)
 
@@ -91,10 +106,21 @@ if ! makecache_with_retry; then
     exit 1
 fi
 {% endif %}
+TXN_BEFORE=$(last_txn_id)
 if ! yum -y update {{ system_update__cache_only | bool | ternary("--cacheonly --setopt=metadata_timer_sync=0", "") }} 1> /dev/null 2> /tmp/system-update-stderr; then
     log "System update failed; see /tmp/system-update-stderr"
     send_msg "$SUBJECT_PREFIX - System update failed" "$(</tmp/system-update-stderr)"
     exit 1
+fi
+
+TXN_AFTER=$(last_txn_id)
+if [ "$TXN_AFTER" = "$TXN_BEFORE" ]; then
+    UPDATED=0
+    TXN_REPORT='No packages were changed in this run.'
+    log "No updates were available"
+else
+    UPDATED=1
+    TXN_REPORT=$(yum history info "$TXN_AFTER")
 fi
 {% endif %}
 
@@ -108,6 +134,18 @@ fi
 apt-get update {{ system_update__cache_only | bool | ternary("--no-download", "") }} 1> /dev/null
 export DEBIAN_FRONTEND=noninteractive
 yes '' | apt-get -y -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" --with-new-pkgs upgrade > /tmp/update_output
+
+# apt closes every run with a summary line; LC_ALL=C above keeps its wording stable.
+# only the first three counters are matched, so a run that changed nothing still counts
+# as a no-op when packages are held back ("... and N not upgraded"). apt 3.0 reworked
+# the output of `apt` but left this `apt-get` line untouched.
+# Verified against apt 2.6 (Debian 12), 3.0 (Debian 13) and 2.7 (Ubuntu 24.04).
+if grep -q '^0 upgraded, 0 newly installed, 0 to remove ' /tmp/update_output; then
+    UPDATED=0
+    log "No updates were available"
+else
+    UPDATED=1
+fi
 {% endif %}
 
 # after any update, notify about new config-file stubs (*.rpmnew / *.rpmsave on RHEL,
@@ -138,7 +176,7 @@ done
 needs-restarting --reboothint &> /dev/null
 if [ $? -eq 1 ]; then
     log "Reboot required (kernel/core component update); requesting reboot via the spool"
-    MSGBODY=$(yum history info)
+    MSGBODY="$TXN_REPORT"
 {% if system_update__post_update_code is defined and system_update__post_update_code | length %}
     post_update_code
 {% endif %}
@@ -150,7 +188,7 @@ fi
 needs-restarting 2> /dev/null > /tmp/needs-restarting
 if [ -s /tmp/needs-restarting ]; then
     log "Reboot required (running services still use pre-update libraries); requesting reboot via the spool"
-    MSGBODY=$(cat /tmp/needs-restarting; yum history info)
+    MSGBODY=$(cat /tmp/needs-restarting; printf '%s\n' "$TXN_REPORT")
 {% if system_update__post_update_code is defined and system_update__post_update_code | length %}
     post_update_code
 {% endif %}
@@ -178,11 +216,20 @@ fi
 post_update_code
 {% endif %}
 
+# stay quiet on an update day that had nothing to apply, the same way the security lane
+# does. the reboot checks above still ran, so a reboot carried over from an earlier
+# window is picked up either way; only the mail is suppressed.
+if [ "$UPDATED" -eq 0 ]; then
+    log "Nothing to report"
+    exit 0
+fi
+
 {% if ansible_facts['os_family'] == 'RedHat' %}
 log "System updated, no reboot required"
-send_msg "$SUBJECT_PREFIX - System updated without Reboot" "$(yum history info)"
+send_msg "$SUBJECT_PREFIX - System updated without Reboot" "$TXN_REPORT"
 {% endif %}
 
 {% if ansible_facts['os_family'] == 'Debian' %}
+log "System updated, no reboot required"
 send_msg "$SUBJECT_PREFIX - System updated without Reboot" "$(cat /tmp/update_output)"
 {% endif %}

--- a/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
+++ b/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026082504
+# 2026082601
 
 # Apply all available updates, then request a reboot if one is needed by dropping a
 # file into the /run/schedule-reboot spool. This script never reboots itself; the
@@ -94,17 +94,39 @@ log "Starting system update"
 # end raw system_update__pre_update_code
 {% endif %}
 
+{% if ansible_facts['os_family'] == 'RedHat' %}
+# The aide rpm ships no check unit at all, so aide-check.timer / aide-check.service are
+# the names the AIDE lane is deployed under here. aide defaults to /etc/aide.conf and
+# keeps the database gzipped.
+# Verified against aide 0.19.2 on Rocky 9.
+AIDE_CONFIG='/etc/aide.conf'
+AIDE_DB='/var/lib/aide/aide.db.gz'
+AIDE_DB_NEW='/var/lib/aide/aide.db.new.gz'
+AIDE_UNIT='aide-check'
+{% endif %}
+{% if ansible_facts['os_family'] == 'Debian' %}
+# aide-common ships dailyaidecheck.timer / dailyaidecheck.service, keeps the database
+# uncompressed, and its aide binary is built without a default config file, so --config
+# is mandatory rather than cosmetic.
+# Verified against aide 0.18.3 and aide-common on Debian 12.
+AIDE_CONFIG='/etc/aide/aide.conf'
+AIDE_DB='/var/lib/aide/aide.db'
+AIDE_DB_NEW='/var/lib/aide/aide.db.new'
+AIDE_UNIT='dailyaidecheck'
+{% endif %}
+
 # remember whether AIDE was already reporting changes before we touch anything. the
 # re-baseline further down would otherwise accept that drift as the new baseline and
-# destroy the finding. `aide --check` exits 1 on a mismatch, so a failed
-# aide-check.service is what "the last check found changes" looks like.
-# Verified against aide 0.19.2 on Rocky 9.
+# destroy the finding. `aide --check` exits 1 on a mismatch, so a failed check service
+# is what "the last check found changes" looks like. both families log to
+# /var/log/aide/aide.log.
+# Verified against aide 0.19.2 on Rocky 9 and aide 0.18.3 on Debian 12.
 AIDE_WAS_CLEAN=0
-if systemctl is-active --quiet aide-check.timer; then
-    if systemctl is-failed --quiet aide-check.service; then
-        log "aide-check was already failing before the update; the database will not be re-baselined"
+if systemctl is-active --quiet "${AIDE_UNIT}.timer"; then
+    if systemctl is-failed --quiet "${AIDE_UNIT}.service"; then
+        log "${AIDE_UNIT} was already failing before the update; the database will not be re-baselined"
         cp /var/log/aide/aide.log /var/log/aide/aide.log-pre-system-update
-        send_msg "$SUBJECT_PREFIX - aide-check.service state was failed before System Update" "Please check the logfile at /var/log/aide/aide.log-pre-system-update (saved before the update ran)."
+        send_msg "$SUBJECT_PREFIX - ${AIDE_UNIT}.service state was failed before System Update" "Please check the logfile at /var/log/aide/aide.log-pre-system-update (saved before the update ran)."
     else
         AIDE_WAS_CLEAN=1
     fi
@@ -133,7 +155,7 @@ TXN_AFTER=$(last_txn_id)
 if [ "$TXN_AFTER" = "$TXN_BEFORE" ]; then
     UPDATED=0
     TXN_REPORT='No packages were changed in this run.'
-    log "No updates were available"
+    log "No packages were changed in this run"
 else
     UPDATED=1
     TXN_REPORT=$(yum history info "$TXN_AFTER")
@@ -170,9 +192,9 @@ fi
 # as a no-op when packages are held back ("... and N not upgraded"). apt 3.0 reworked
 # the output of `apt` but left this `apt-get` line untouched.
 # Verified against apt 2.6 (Debian 12), 3.0 (Debian 13) and 2.7 (Ubuntu 24.04).
-if grep -q '^0 upgraded, 0 newly installed, 0 to remove ' /tmp/update_output; then
+if grep --quiet '^0 upgraded, 0 newly installed, 0 to remove ' /tmp/update_output; then
     UPDATED=0
-    log "No updates were available"
+    log "No packages were changed in this run"
 else
     UPDATED=1
 fi
@@ -184,9 +206,9 @@ fi
 # and only when the check was passing beforehand: re-baselining an already-failing check
 # would silently accept whatever drifted since the last run, an intrusion included.
 if [ "$AIDE_WAS_CLEAN" -eq 1 ] && [ "$UPDATED" -eq 1 ]; then
-    aide --update 1> /dev/null
-    \mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
-    systemctl restart aide-check.service
+    aide --config="$AIDE_CONFIG" --update 1> /dev/null
+    \mv "$AIDE_DB_NEW" "$AIDE_DB"
+    systemctl restart "${AIDE_UNIT}.service"
 fi
 
 # after any update, notify about new config-file stubs (*.rpmnew / *.rpmsave on RHEL,
@@ -214,10 +236,14 @@ done
 
 # any restarts needed? if so, request a reboot via the spool (do not reboot here)
 {% if ansible_facts['os_family'] == 'RedHat' %}
-needs-restarting --reboothint &> /dev/null
+# keep the hint itself: it names the core packages that ask for the reboot, which is the
+# only explanation the admin gets when the reboot is carried over from an earlier window
+# and this run changed nothing.
+# Verified against dnf-utils on Rocky 9.
+needs-restarting --reboothint > /tmp/reboothint 2>&1
 if [ $? -eq 1 ]; then
     log "Reboot required (kernel/core component update); requesting reboot via the spool"
-    MSGBODY="$TXN_REPORT"
+    MSGBODY=$(cat /tmp/reboothint; printf '%s\n' "$TXN_REPORT")
 {% if system_update__post_update_code is defined and system_update__post_update_code | length %}
     post_update_code
 {% endif %}

--- a/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
+++ b/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026082501
+# 2026082502
 
 # Apply all available updates, then request a reboot if one is needed by dropping a
 # file into the /run/schedule-reboot spool. This script never reboots itself; the
@@ -89,9 +89,20 @@ log "Starting system update"
 # end raw system_update__pre_update_code
 {% endif %}
 
-if systemctl is-active --quiet aide-check.timer && systemctl is-failed --quiet aide-check.service; then
-    cp /var/log/aide/aide.log /var/log/aide/aide.log-pre-system-update
-    send_msg "$SUBJECT_PREFIX - aide-check.service state was failed before System Update" "Please check the logfile at /var/log/aide/aide.log-pre-system-update (saved before the update ran)."
+# remember whether AIDE was already reporting changes before we touch anything. the
+# re-baseline further down would otherwise accept that drift as the new baseline and
+# destroy the finding. `aide --check` exits 1 on a mismatch, so a failed
+# aide-check.service is what "the last check found changes" looks like.
+# Verified against aide 0.19.2 on Rocky 9.
+AIDE_WAS_CLEAN=0
+if systemctl is-active --quiet aide-check.timer; then
+    if systemctl is-failed --quiet aide-check.service; then
+        log "aide-check was already failing before the update; the database will not be re-baselined"
+        cp /var/log/aide/aide.log /var/log/aide/aide.log-pre-system-update
+        send_msg "$SUBJECT_PREFIX - aide-check.service state was failed before System Update" "Please check the logfile at /var/log/aide/aide.log-pre-system-update (saved before the update ran)."
+    else
+        AIDE_WAS_CLEAN=1
+    fi
 fi
 
 # do the update, and print only critical errors about which we must be told
@@ -124,12 +135,6 @@ else
 fi
 {% endif %}
 
-if systemctl is-active --quiet aide-check.timer; then
-    aide --update 1> /dev/null
-    \mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
-    systemctl restart aide-check.service
-fi
-
 {% if ansible_facts['os_family'] == 'Debian' %}
 apt-get update {{ system_update__cache_only | bool | ternary("--no-download", "") }} 1> /dev/null
 export DEBIAN_FRONTEND=noninteractive
@@ -147,6 +152,17 @@ else
     UPDATED=1
 fi
 {% endif %}
+
+# re-baseline AIDE after the transaction, so the database describes the updated
+# filesystem. This sits below both distribution blocks because the Debian transaction
+# runs further down than the RedHat one. Only when this run actually changed packages,
+# and only when the check was passing beforehand: re-baselining an already-failing check
+# would silently accept whatever drifted since the last run, an intrusion included.
+if [ "$AIDE_WAS_CLEAN" -eq 1 ] && [ "$UPDATED" -eq 1 ]; then
+    aide --update 1> /dev/null
+    \mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
+    systemctl restart aide-check.service
+fi
 
 # after any update, notify about new config-file stubs (*.rpmnew / *.rpmsave on RHEL,
 # *.dpkg-dist / *.ucf-dist on Debian). one mail per file, sent via sendmail.

--- a/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
+++ b/roles/system_update/templates/usr/local/sbin/update-and-reboot.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # {{ ansible_managed }}
-# 2026082503
+# 2026082504
 
 # Apply all available updates, then request a reboot if one is needed by dropping a
 # file into the /run/schedule-reboot spool. This script never reboots itself; the
@@ -25,7 +25,7 @@ send_msg () {
         printf 'Content-Type: text/plain; charset="utf-8"\n'
         printf 'Content-Transfer-Encoding: 8bit\n'
         printf '\n%s\n' "$body"
-    } | sendmail -oi -t -f "$SENDER"
+    } | sendmail -oi -t -f "$MAIL_FROM"
 {% if system_update__rocketchat_url is defined and system_update__rocketchat_url | length %}
     /usr/bin/curl --silent --output /dev/null --data-urlencode \
         "text=${subject}
@@ -71,7 +71,12 @@ last_txn_id () {
 {% endif %}
 
 SUBJECT_PREFIX="{{ system_update__mail_subject_prefix }}{{ system_update__mail_subject_hostname }}"
-SENDER="$SUBJECT_PREFIX <{{ system_update__mail_from }}>"
+MAIL_FROM='{{ system_update__mail_from }}'
+# RFC 5322 permits only atoms in an unquoted display name. A subject prefix such as
+# "[system_update] " carries brackets, which are specials, and a strict parser then
+# drops the whole address rather than just the name. So quote the display name, escaping
+# any embedded backslash or double quote.
+SENDER="\"$(printf '%s' "$SUBJECT_PREFIX" | sed 's/[\\"]/\\&/g')\" <$MAIL_FROM>"
 RECIPIENTS="{{ system_update__mail_recipients_updates | join(' ' ) }}"
 RECIPIENTS_NEW_CONFIGFILES="{{ system_update__mail_recipients_new_configfiles | join(' ' ) }}"
 
@@ -204,7 +209,7 @@ find / -mount \( -name '*.rpmnew' -o -name '*.rpmsave' -o -name '*.dpkg-dist' -o
         printf 'Content-Type: text/plain; charset="utf-8"\n'
         printf 'Content-Transfer-Encoding: 8bit\n'
         printf '\n%s\n' "$configfile"
-    } | sendmail -oi -t -f "$SENDER"
+    } | sendmail -oi -t -f "$MAIL_FROM"
 done
 
 # any restarts needed? if so, request a reboot via the spool (do not reboot here)


### PR DESCRIPTION
The weekly update mails were misreporting on every host. This started as a review of two weeks of `system_update` / `schedule_reboot` mail from a ~24 host fleet, where 20 of 21 "System updated without Reboot" mails on one update day were false.

## What was wrong

**1. A mail on every update day, describing an earlier run.** `update-and-reboot` used to be queued by `at(1)` from the "updates are available" branch of `notify-and-schedule`, so it never ran on a week with nothing pending. Moving it onto its own timer in v8.0.0 made it run every update day, but its closing `send_msg` stayed unconditional. The body made it worse: a bare `yum history info` prints the *last* transaction, so a quiet week produced one mail per host listing the previous week's packages, kernel installs included. A mail titled "System updated without Reboot" whose body was a kernel install that had required one.

The security lane already had the right gate, but wrote a bare `yum history info` into the reboot spool, so an upgrade that installed nothing after all handed `do-reboot` an unrelated transaction. On a day where both lanes run, that is the weekly lane's transaction from minutes earlier.

**2. AIDE was re-baselined at the wrong time, and unconditionally.** The `aide --update` block sat directly below the RedHat transaction while the Debian transaction runs further down, so on Debian the database was refreshed against the pre-upgrade filesystem and the next `aide-check` flagged every file the upgrade had touched. It has been that way since the block was introduced.

It also ran unconditionally. The script already detects that `aide-check.service` was failing beforehand, mails about it and saves the log, then re-baselined three lines later and restarted the unit, clearing the failed state and burying the very finding it had just reported.

**3. The Debian lane checked no return codes.** A failing maintainer script returns 100, but the run continued into the reboot decision and the closing notification, so a broken transaction produced a success mail or rebooted a half-configured host.

**4. The `From` header was invalid whenever a subject prefix is set.** `SENDER` was built as `"$SUBJECT_PREFIX <address>"`, putting brackets into an unquoted display name. RFC 5322 permits only atoms there, so a strict parser returns an *empty address*, not merely a mangled display name. Any consumer built on one sees mail with no sender at all. Hosts without a prefix were unaffected, which is why it went unnoticed.

## What changed

Each commit is self-contained:

| Commit | Change |
| --- | --- |
| `b09a243a` | Capture the dnf transaction id before and after the transaction, report only the one this run created, stay quiet when there is none. Same for the security lane. |
| `6be246a4` | Re-baseline AIDE after the transaction on both distributions, and only when the run changed packages and the check was passing beforehand. |
| `e977bb95` | Check both `apt-get update` and `apt-get upgrade`. |
| `c192278b` | Quote the `From` display name; pass the bare address to `sendmail -f`. |

The reboot checks still run when nothing was updated, so a reboot carried over from an earlier window is picked up either way; its spool entry then says that no packages changed instead of repeating an old transaction.

## Behaviour changes worth noting

- A host whose AIDE check was already failing keeps failing, instead of having the weekly update quietly clear it. That is the point of the change, but it is visible in monitoring.
- Hosts with nothing to update go silent on their update day.

## Not covered

`apt-get update` exits 0 when a mirror merely fails to answer, printing a `W: Failed to fetch` warning and carrying on with the old lists. It only reports a non-zero status for hard errors such as an unreadable sources list, so the new check catches a broken configuration, not a mirror outage. Its stderr keeps going to the journal, where an outage stays visible. Closing that gap needs a Debian counterpart to `makecache_with_retry` and is deliberately not part of this PR.

## Verification

Templates rendered for RedHat and Debian, with and without `cache_only`, pre/post hooks and Rocket.Chat, all passing `bash -n` and `shellcheck`; `pre-commit run --files` clean.

Behaviour was measured in containers rather than reasoned about:

- **dnf**, Rocky 9: an up-to-date host running `yum -y update` again exits 0 with "Nothing to do" and leaves the transaction id unchanged, while a bare `yum history info` still prints the previous transaction in full. Rendered script run twice: one mail, not two. Carried-over reboot case: reboot still requested, spool entry reads `No packages were changed in this run.`
- **AIDE**: `aide --check` exits 1 on a mismatch (aide 0.19.2, Rocky 9), which is what makes `is-failed` a valid signal. Full gating matrix exercised: clean+updates re-baselines, clean+no-updates does not, already-failing does not and leaves the unit failed with the pre-update log preserved, AIDE-not-managed is a no-op.
- **apt**, Debian 12: a package whose `postinst` exits 1 makes `apt-get upgrade` return 100 and the script exit 1 with a failure mail carrying both streams, and no reboot requested. An unreachable mirror returns 0 with only `W:` warnings; a malformed sources list returns 100.
- **Mail headers**: parsed with a strict RFC 5322 parser. The old form yields `addr=''` with `InvalidHeaderDefect`; the new form parses intact, including prefixes containing a double quote or a backslash. End to end through Postfix 3.5.25 on Rocky 9, reading the queued message directly.
