### PR TITLE
fix(plugins/bitwarden_item): point the locked-vault error at bw serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **plugin:bitwarden_item, module:bitwarden_item**: A vault that is not unlocked is reported with the `bw serve` endpoint it was read from and the status it actually has, plus the hint that `bw serve` keeps the session it was started with. The previous message pointed at `bw login` and `bw unlock`, which do not reach a running `bw serve`.
+* **plugin:bitwarden_item**: Error messages no longer carry a doubled period in the middle.
 * **role:rocketchat**: The container image is pulled from Docker Hub directly instead of through `registry.rocket.chat`, whose pull rate limit is shared by everyone using it, so image pulls and `podman auto-update` no longer fail with `toomanyrequests`.
 * **role:system_update**: A requested reboot names the core packages or the running services that ask for it, instead of only listing what the run changed.
 * **role:system_update**: A host with nothing to update no longer sends a "System updated without Reboot" mail on every update day.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ bw status | jq
 bw serve --hostname 127.0.0.1 --port 8087 &
 ```
 
+The order matters. `bw serve` takes its session from the environment it is started in and keeps it for its lifetime, so exporting `BW_SESSION` afterwards does not reach a running instance. In that case `bw status` reports `unlocked` while the API Ansible talks to is still locked. Check the API itself with `curl --silent http://127.0.0.1:8087/status`, and restart `bw serve` if it disagrees with your shell.
+
 The lookup returns multiple keys, including `username` and `password`. To get only the password:
 
 ```yaml

--- a/plugins/lookup/bitwarden_item.py
+++ b/plugins/lookup/bitwarden_item.py
@@ -36,6 +36,7 @@ notes:
 requirements:
     - Bitwarden CLI C(bw) version v2022.9.0 or newer. See U(https://bitwarden.com/help/article/cli/) for installation instructions.
     - You must be logged in and unlocked (C(bw login) followed by C(bw unlock)), and have the local API running, e.g. C(bw serve --hostname 127.0.0.1 --port 8087). The plugin connects to C(127.0.0.1:8087) by default.
+    - C(bw serve) takes its session from the environment it is started in and keeps it for its lifetime. Export C(BW_SESSION) before starting it. Unlocking the vault afterwards only affects the C(bw) CLI in your shell, so C(bw status) can report C(unlocked) while the API the plugin talks to is still locked.
 
 author:
     - Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
@@ -314,10 +315,9 @@ class LookupModule(LookupBase):
 
         bw = Bitwarden()
 
-        if not bw.is_unlocked:
-            raise AnsibleError(
-                'Not logged into Bitwarden, or Bitwarden Vault is locked. Please run `bw login` and `bw unlock` first.'
-            )
+        status = bw.status
+        if status != 'unlocked':
+            raise AnsibleError(bw.get_not_unlocked_message(status))
         display.vvv('lfbwlp - run - bitwarden vault is unlocked')
 
         bw.sync()
@@ -357,7 +357,7 @@ class LookupModule(LookupBase):
                     continue  # done here, go to next term
                 else:
                     # item not found by ID. if there is an ID given we expect it to exist
-                    raise AnsibleError(f'Item with id {id_} not found.')
+                    raise AnsibleError(f'Item with id {id_} not found')
 
             name = Bitwarden.get_pretty_name(name, hostname, purpose)
             display.vvv(f'lfbwlp - run - get item: {name}')
@@ -367,7 +367,7 @@ class LookupModule(LookupBase):
 
             if len(result) > 1:
                 raise AnsibleError(
-                    'Found multiple Bitwarden items with the same name/title and username, cannot decide which one to use. Aborting.'
+                    'Found multiple Bitwarden items with the same name/title and username, cannot decide which one to use. Aborting'
                 )
 
             if len(result) == 1:
@@ -380,7 +380,7 @@ class LookupModule(LookupBase):
                 # the user declared that this run must not mint new secrets
                 raise AnsibleError(
                     f'Bitwarden item "{name}" not found, and item creation is disabled '
-                    '(LFOPS_BITWARDEN_LOOKUP_ITEM_CREATE=false). Aborting.'
+                    '(LFOPS_BITWARDEN_LOOKUP_ITEM_CREATE=false). Aborting'
                 )
             else:
                 display.vvv('lfbwlp - run - no item found. generating new one')

--- a/plugins/module_utils/bitwarden.py
+++ b/plugins/module_utils/bitwarden.py
@@ -273,10 +273,29 @@ class Bitwarden:
         return copy.deepcopy(self._cache['templates'][template_name])
 
     @property
-    def is_unlocked(self):
-        """Check if the Bitwarden vault is unlocked."""
+    def status(self):
+        """Vault status as reported by the `bw serve` API.
+
+        Exactly one of 'unauthenticated' (not logged in), 'locked' (logged in, vault
+        locked) or 'unlocked'. Verified against the StatusCommand of bw 2026.8.0, which
+        declares these three and no others.
+        """
         result = self._api_call('status')
-        return result['data']['template']['status'] == 'unlocked'
+        return result['data']['template']['status']
+
+    def get_not_unlocked_message(self, status):
+        """Error message for a `bw serve` whose vault cannot be read.
+
+        Shared by the lookup plugin and the module so both give the same advice.
+        """
+        return (
+            f'The Bitwarden vault behind `bw serve` at {self._base_url} reports '
+            f'status "{status}", expected "unlocked". `bw serve` keeps its own session, '
+            'taken from the environment it was started in, so `bw status` in your '
+            'shell can report "unlocked" while this API does not. Run `bw login` if '
+            'needed, then `export BW_SESSION="$(bw unlock --raw)"` and restart '
+            '`bw serve`'
+        )
 
     def sync(self, force=False, interval=60):
         """Pull the latest vault data from server and repopulate the items cache.
@@ -394,10 +413,10 @@ class Bitwarden:
         characters (0-9 and a-f).
         """
         if password_length <= 0:
-            raise ValueError('Password length must be a positive integer.')
+            raise ValueError('Password length must be a positive integer')
         if password_choice.lower() == '0123456789abcdef' and password_length % 2 != 0:
             raise ValueError(
-                'Password length must be an even number to represent full hex bytes.'
+                'Password length must be an even number to represent full hex bytes'
             )
         return ''.join(secrets.choice(password_choice) for _ in range(password_length))
 

--- a/plugins/modules/bitwarden_item.py
+++ b/plugins/modules/bitwarden_item.py
@@ -36,6 +36,7 @@ notes:
 requirements:
     - Bitwarden CLI C(bw) version v2022.9.0 or newer. See U(https://bitwarden.com/help/article/cli/) for installation instructions.
     - You must be logged in and unlocked (C(bw login) followed by C(bw unlock)), and have the local API running, e.g. C(bw serve --hostname 127.0.0.1 --port 8087). The module connects to C(127.0.0.1:8087) by default.
+    - C(bw serve) takes its session from the environment it is started in and keeps it for its lifetime. Export C(BW_SESSION) before starting it. Unlocking the vault afterwards only affects the C(bw) CLI in your shell, so C(bw status) can report C(unlocked) while the API the module talks to is still locked.
 
 author:
     - Linuxfabrik GmbH, Zurich, Switzerland, https://www.linuxfabrik.ch
@@ -344,10 +345,9 @@ def run_module():
 
     bw = Bitwarden()
 
-    if not bw.is_unlocked:
-        module.fail_json(
-            msg='Not logged into Bitwarden, or Bitwarden Vault is locked. Please run `bw login` and `bw unlock` first.'
-        )
+    status = bw.status
+    if status != 'unlocked':
+        module.fail_json(msg=bw.get_not_unlocked_message(status))
 
     # to be sure we are up to date
     bw.sync()

--- a/tests/unit/plugins/lookup/test_bitwarden_item.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_item.py
@@ -46,13 +46,17 @@ class _FakeBitwarden:
     items_by_search: ClassVar[list] = []
     item_by_id = None
     created_items: ClassVar[list] = []
+    vault_status = 'unlocked'
 
     def __init__(self, *args, **kwargs):
         pass
 
     @property
-    def is_unlocked(self):
-        return True
+    def status(self):
+        return type(self).vault_status
+
+    def get_not_unlocked_message(self, status):
+        return f'vault reports status "{status}"'
 
     def sync(self, *args, **kwargs):
         pass
@@ -100,6 +104,7 @@ class _BitwardenLookupTestCase(unittest.TestCase):
         _FakeBitwarden.items_by_search = []
         _FakeBitwarden.item_by_id = None
         _FakeBitwarden.created_items = []
+        _FakeBitwarden.vault_status = 'unlocked'
         # a value leaking in from the caller's environment would flip the
         # default of the `create` option under the tests' feet
         self._orig_create_env = os.environ.pop(CREATE_ENV_VAR, None)
@@ -124,6 +129,15 @@ class TestRun(_BitwardenLookupTestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['username'], 'dba')
         self.assertEqual(result[0]['password'], 'linuxfabrik')
+
+    def test_vault_not_unlocked_aborts(self):
+        for status in ('unauthenticated', 'locked'):
+            with self.subTest(status=status):
+                _FakeBitwarden.vault_status = status
+                with self.assertRaises(AnsibleError) as ctx:
+                    self.lookup.run([{'name': 'host - db', 'username': 'dba'}])
+                self.assertIn(status, str(ctx.exception))
+                self.assertEqual(_FakeBitwarden.created_items, [])
 
     def test_multiple_matches_raise(self):
         _FakeBitwarden.items_by_search = [

--- a/tests/unit/plugins/module_utils/test_bitwarden.py
+++ b/tests/unit/plugins/module_utils/test_bitwarden.py
@@ -143,6 +143,41 @@ class TestApiCall(unittest.TestCase):
             self.bw._api_call('status')
 
 
+class TestStatus(unittest.TestCase):
+    def setUp(self):
+        self.bw = _make_bitwarden()
+        self._orig_open_url = bitwarden.open_url
+
+    def tearDown(self):
+        bitwarden.open_url = self._orig_open_url
+
+    def _serve_status(self, status):
+        bitwarden.open_url = lambda *a, **k: _FakeResponse(
+            {
+                'success': True,
+                'data': {'object': 'template', 'template': {'status': status}},
+            }
+        )
+
+    def test_status_is_passed_through(self):
+        # the complete set of values bw reports, see the status property
+        for status in ('unauthenticated', 'locked', 'unlocked'):
+            with self.subTest(status=status):
+                self._serve_status(status)
+                self.assertEqual(self.bw.status, status)
+
+    def test_not_unlocked_message_names_endpoint_and_status(self):
+        message = self.bw.get_not_unlocked_message('locked')
+        self.assertIn('http://127.0.0.1:8087', message)
+        self.assertIn('"locked"', message)
+        self.assertIn('bw serve', message)
+
+    def test_not_unlocked_message_has_no_trailing_period(self):
+        # AnsibleError appends ". <original message>" when it wraps an exception,
+        # so a trailing period would show up doubled in the playbook output
+        self.assertFalse(self.bw.get_not_unlocked_message('locked').endswith('.'))
+
+
 class TestGetItems(unittest.TestCase):
     def setUp(self):
         self.bw = _make_bitwarden()

--- a/tests/unit/plugins/modules/test_bitwarden_item.py
+++ b/tests/unit/plugins/modules/test_bitwarden_item.py
@@ -92,13 +92,17 @@ class _FakeBitwarden:
     items: ClassVar[list] = []
     edited: ClassVar[list] = []
     created: ClassVar[list] = []
+    vault_status = 'unlocked'
 
     def __init__(self, *args, **kwargs):
         pass
 
     @property
-    def is_unlocked(self):
-        return True
+    def status(self):
+        return type(self).vault_status
+
+    def get_not_unlocked_message(self, status):
+        return f'vault reports status "{status}"'
 
     def sync(self, *args, **kwargs):
         pass
@@ -160,6 +164,7 @@ class TestMain(unittest.TestCase):
         _FakeBitwarden.items = []
         _FakeBitwarden.edited = []
         _FakeBitwarden.created = []
+        _FakeBitwarden.vault_status = 'unlocked'
         self._patchers = [
             unittest.mock.patch.object(mod, 'Bitwarden', _FakeBitwarden),
             ansible_harness.patch_module(),
@@ -178,6 +183,16 @@ class TestMain(unittest.TestCase):
         except ansible_harness.AnsibleExitJson as exc:
             return exc.args[0]
         raise AssertionError('module did not call exit_json')
+
+    def test_vault_not_unlocked_fails(self):
+        for status in ('unauthenticated', 'locked'):
+            with self.subTest(status=status):
+                _FakeBitwarden.vault_status = status
+                ansible_harness.set_module_args({'name': 'host - db'})
+                with self.assertRaises(ansible_harness.AnsibleFailJson) as ctx:
+                    mod.run_module()
+                self.assertIn(status, ctx.exception.args[0]['msg'])
+                self.assertEqual(_FakeBitwarden.created, [])
 
     def test_check_mode_create_does_not_write(self):
         _FakeBitwarden.items = []  # nothing exists -> would create


### PR DESCRIPTION
## Problem

The lookup and the module read the vault through the `bw serve` API on `127.0.0.1:8087`. That daemon keeps the session it was started with, so exporting `BW_SESSION` afterwards only reaches the `bw` CLI in the shell:

```
$ bw status
{"status":"unlocked", ...}

$ curl --silent http://127.0.0.1:8087/status
{"data":{"template":{"status":"locked", ...

$ tr '\0' '\n' < /proc/<pid of bw serve>/environ | grep BW_
BW_SESSION=
```

The old message sent the admin to `bw login` and `bw unlock`, neither of which touches a running `bw serve`, so the obvious next step was the wrong one.

## Change

`is_unlocked` is replaced by `status`, which passes the raw value through, so the message can name what the API actually reported. The complete set of values is `unauthenticated`, `locked` and `unlocked`, verified against the `StatusCommand` of bw 2026.8.0:

```ts
private async status(userId): Promise<"unauthenticated" | "locked" | "unlocked">
```

Both call sites share one message builder in the module_util so they cannot drift apart. What an admin sees now:

```
The Bitwarden vault behind `bw serve` at http://127.0.0.1:8087 reports status "locked",
expected "unlocked". `bw serve` keeps its own session, taken from the environment it was
started in, so `bw status` in your shell can report "unlocked" while this API does not.
Run `bw login` if needed, then `export BW_SESSION="$(bw unlock --raw)"` and restart `bw serve`
```

The same trap is now documented in the `requirements` of both DOCUMENTATION blocks and in the README section that shows the `bw serve` setup.

Second, unrelated to the content: every raised message lost its trailing period. `AnsibleError` appends `". <original message>"` when it wraps an exception (`ansible/errors/__init__.py`), so the period showed up doubled in the playbook output:

```
before: ... `bw unlock` first.. Not logged into Bitwarden, ...
after:  ... `bw serve`. The Bitwarden vault behind `bw serve` at ...
```

## Tests

New `TestStatus` in the module_util tests covers the three status values, the message content (endpoint, status, `bw serve`) and the missing trailing period, with the reason in a comment. The lookup and module tests gained a settable vault status and one test each asserting that `unauthenticated` and `locked` abort without creating anything.

`tox -e py313-ansible218`: 135 passed. `ruff`, `bandit` and `vulture` clean via `pre-commit`.
