### PR TITLE
feat(roles/shared)!: factor out the reboot pattern and apply it to three more roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+* **playbook:crypto_policy, playbook:kernel_modules, playbook:selinux**: These playbooks run `postfix`, `mailto_root` and `schedule_reboot` before their own role, so that a change needing a reboot can request one. `mailto_root__from` and `mailto_root__to` are therefore mandatory for them; a host set up with `setup_basic` already has both. To keep a playbook as it was, set `<playbook>__skip_postfix`, `<playbook>__skip_mailto_root` and `<playbook>__skip_schedule_reboot` to `true`, for example `crypto_policy__skip_schedule_reboot: true`.
 * **role:fail2ban**: Removed `apache-404-matomo` filter and jail. The `apache-404` filter now matches all supported LogFormats including matomo and vhost_common. Remove `apache-404-matomo` entries from `fail2ban__filters__*_var` and `fail2ban__jails__*_var` in your inventory and use `apache-404` instead.
 * **role:fail2ban**: Rename `fail2ban__jail_apache_404_ignoreregex` to `fail2ban__filter_apache_404_ignoreregex` in your inventory. The regular expressions land in the `apache-404` and `apache-404-matomo` filters, which both jails share, so the old name pointed at a jail that never carried the setting. The value itself is unchanged.
 
 ### Added
 
+* **role:crypto_policy, role:kernel_modules, role:selinux**: A change that only takes effect after a reboot requests one at the maintenance window instead of being left to the operator to notice: a switched crypto policy, a blocked kernel module that is still loaded, and switching SELinux on or off. Where the reboot mechanism is not deployed, the role reports the pending reboot as before. `lfops__reboot_now` performs it in the same run.
 * Every playbook prints the manual steps a run leaves to the operator as one block directly above the `PLAY RECAP`, collected from all roles of the play instead of scattered over its output. The roles keep printing their message where it occurs as well, so a role used outside this collection still reports it.
 * **role:bootloader**: New role that manages the kernel command line, for parameters that only take effect at boot time such as `psi=1`. Options are applied to every boot entry of the host, on the Red Hat family with `grubby` and on Debian and Ubuntu through a GRUB drop-in of its own. A changed command line requests a reboot at the maintenance window instead of rebooting right away, or applies it during the run when `lfops__reboot_now` is set, and a `--check` run reports what it would change without touching the host.
 * **role:fail2ban**: The `fail2ban:configure` tag deploys the actions, filters and jails without touching the packages.
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* **playbook:setup_basic**: The mail and reboot roles run before the security roles, so a first run against a fresh host files the reboot request that a changed crypto policy, SELinux state or kernel module blocklist needs. Until now the reboot mechanism was deployed further down the playbook and such a change could only be reported to the operator.
 * **role:network**: The reminder that NetworkManager may have to be restarted by hand is printed only when a connection profile actually changed, instead of on every run.
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -457,16 +457,52 @@ The resulting behaviour, from the operator's point of view:
 
 The last two rows are the point of the pattern: a reboot the operator explicitly asked for must not degrade into a debug message, and a deploy whose reboot request was lost must not report success.
 
-[roles/bootloader](https://github.com/Linuxfabrik/lfops/tree/main/roles/bootloader) is the reference implementation. Its `tasks/main.yml` covers every row of the table above, in two places: the precondition assert sits in the validation block at the top, the reboot tasks themselves at the end. Copy both and replace the reason (`bootloader`), the detail text and the role-internal variable that says a reboot is needed.
+The pattern lives in two task files of the `shared` role, so there is one implementation to fix when something about it is wrong. A consuming role wires them in at two points, and never spells out the mechanism itself:
 
-Notes on that pattern:
+* `shared/tasks/assert-reboot-possible.yml` goes into the role's validation block, tagged `always`.
+* `shared/tasks/request-reboot.yml` goes where the role knows whether it changed something, gated on that condition.
+
+```yaml
+# roles/example/tasks/main.yml, in the validation block
+  # a precondition, not a result: the host cannot perform the reboot lfops__reboot_now asks of it,
+  # so the run is refused before anything is written rather than after.
+  - name: 'Assert that a reboot is possible'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'assert-reboot-possible.yml'
+
+  tags:
+    - 'always'
+```
+
+```yaml
+# roles/example/tasks/main.yml, after the change was made
+  - name: 'Request a reboot'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'request-reboot.yml'
+    vars:
+      shared__reboot_reason: 'example'
+      shared__reboot_detail: 'kernel command line changed'
+    when:
+      - '__example__reboot_needed | bool'
+```
+
+[roles/bootloader](https://github.com/Linuxfabrik/lfops/tree/main/roles/bootloader) is the reference implementation; [roles/crypto_policy](https://github.com/Linuxfabrik/lfops/tree/main/roles/crypto_policy), [roles/kernel_modules](https://github.com/Linuxfabrik/lfops/tree/main/roles/kernel_modules) and [roles/selinux](https://github.com/Linuxfabrik/lfops/tree/main/roles/selinux) are the other consumers.
+
+Choosing the condition is the part the shared files cannot do for you:
+
+* **Gate on this run having changed something, not on the host still needing a reboot.** The two differ whenever the signal stays true until the host reboots, which is the normal case for a state the running kernel cannot change: `ansible.posix.selinux` keeps reporting `reboot_required` on every run until SELinux is actually switched on. Requesting on that alone reports a change on every run, fails the Molecule `idempotence` step, and buys nothing, because the spool file lives in `/run` and outlives those runs. Requesting on the run that made the change is enough, and it is what makes "nothing changed, no request and no message" the first row of the table above.
+* **Do not request a reboot for a change with no runtime effect.** A configuration file that blocks a kernel module needs a reboot only when one of those modules is currently loaded; without that check every fresh host would reboot for a default that changes nothing on it. `roles/kernel_modules` reads `/proc/modules` for exactly that reason.
+* **Do not use `ansible.builtin.reboot`.** It bypasses the notification mail, the Icinga downtime and the coalescing with other pending requests, and it leaves the host's reboot state invisible to `schedule_reboot`.
+* **Check mode is safe without extra guards**, since `ansible.builtin.command` does not run under `--check`. A check run reports the pending change and touches nothing.
+
+Why `request-reboot.yml` is built the way it is, for whoever has to change it:
 
 * **Fire and forget is mandatory, not an optimisation.** `--now` starts `schedule-reboot.service`, whose actor sends the notification, sets the downtime, sleeps the grace period and reboots. A synchronous task would die on the dropped connection and fail the run after a reboot that actually succeeded. Killing the async wrapper does not stop the systemd unit, so the reboot happens either way.
 * **Wait for the host to go down before waiting for it to come back.** A `wait_for` on the SSH port with `state: 'stopped'`, delegated to the controller, has to sit between the two. Waiting only for the host to return looks equivalent but is not: the actor mails the administrators and calls the Icinga API before it sleeps the grace period, so the moment the host goes down is not bounded by any delay the role can compute. A slow `sendmail` or an unreachable Icinga endpoint is enough for the connection check to succeed against the still-running host, report the reboot as done, and let the play continue into a host that goes down moments later. On hosts reached through a jump host or a `ProxyCommand` this probes the wrong path; compare `/proc/sys/kernel/random/boot_id` before and after instead.
 * **`wait_for_connection` belongs to the same branch.** Without it, everything after the role in the play runs against a host that is going down.
-* **Do not use `ansible.builtin.reboot`.** It bypasses the notification mail, the Icinga downtime and the coalescing with other pending requests, and it leaves the host's reboot state invisible to `schedule_reboot`.
 * **Two tasks, not one with a conditional `argv`.** The two branches differ in more than the argument: only one of them is asynchronous, and only one can evaluate `rc` for `changed_when`.
-* **Check mode is safe without extra guards**, since `ansible.builtin.command` does not run under `--check`. A check run reports the pending change and touches nothing.
 * **The precondition belongs in the validation block**, next to the role's other asserts and tagged `always`, not next to the reboot tasks. Whether the host can reboot at all is a precondition of the mode the operator asked for, so it is decided before the role writes anything, and it is not gated on whether this particular run needs a reboot. Gating it there would surface the contradiction only on the run that happens to change something, which is the run that can least afford it.
 
 A role that requests reboots also has to:

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -198,6 +198,9 @@ Calls the following roles (in order):
 
 Calls the following roles (in order):
 
+* [postfix](https://github.com/Linuxfabrik/lfops/tree/main/roles/postfix): `crypto_policy__skip_postfix`
+* [mailto_root](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailto_root): `crypto_policy__skip_mailto_root`
+* [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot): `crypto_policy__skip_schedule_reboot`
 * [crypto_policy](https://github.com/Linuxfabrik/lfops/tree/main/roles/crypto_policy)
 
 
@@ -516,6 +519,9 @@ Calls the following roles (in order):
 
 Calls the following roles (in order):
 
+* [postfix](https://github.com/Linuxfabrik/lfops/tree/main/roles/postfix): `kernel_modules__skip_postfix`
+* [mailto_root](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailto_root): `kernel_modules__skip_mailto_root`
+* [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot): `kernel_modules__skip_schedule_reboot`
 * [kernel_modules](https://github.com/Linuxfabrik/lfops/tree/main/roles/kernel_modules)
 
 
@@ -1031,6 +1037,9 @@ Calls the following roles (in order):
 Calls the following roles (in order):
 
 * [policycoreutils](https://github.com/Linuxfabrik/lfops/tree/main/roles/policycoreutils): `selinux__skip_policycoreutils`
+* [postfix](https://github.com/Linuxfabrik/lfops/tree/main/roles/postfix): `selinux__skip_postfix`
+* [mailto_root](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailto_root): `selinux__skip_mailto_root`
+* [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot): `selinux__skip_schedule_reboot`
 * [selinux](https://github.com/Linuxfabrik/lfops/tree/main/roles/selinux)
 
 
@@ -1041,6 +1050,11 @@ Calls the following roles (in order):
 * [network](https://github.com/Linuxfabrik/lfops/tree/main/roles/network): `setup_basic__skip_network`
 * [repo_baseos](https://github.com/Linuxfabrik/lfops/tree/main/roles/repo_baseos): `setup_basic__skip_repo_baseos`
 * [repo_epel](https://github.com/Linuxfabrik/lfops/tree/main/roles/repo_epel): `setup_basic__skip_repo_epel`
+* [hostname](https://github.com/Linuxfabrik/lfops/tree/main/roles/hostname): `setup_basic__skip_hostname`
+* [mailx](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailx): `setup_basic__skip_mailx`
+* [postfix](https://github.com/Linuxfabrik/lfops/tree/main/roles/postfix): `setup_basic__skip_postfix`
+* [mailto_root](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailto_root): `setup_basic__skip_mailto_root`
+* [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot): `setup_basic__skip_schedule_reboot`
 * [crypto_policy](https://github.com/Linuxfabrik/lfops/tree/main/roles/crypto_policy): `setup_basic__skip_crypto_policy`
 * [policycoreutils](https://github.com/Linuxfabrik/lfops/tree/main/roles/policycoreutils): `setup_basic__skip_policycoreutils`
 * [selinux](https://github.com/Linuxfabrik/lfops/tree/main/roles/selinux): `setup_basic__skip_selinux`
@@ -1048,7 +1062,6 @@ Calls the following roles (in order):
 * [kernel_settings](https://github.com/Linuxfabrik/lfops/tree/main/roles/kernel_settings): `setup_basic__skip_kernel_settings`
 * [core_dumps](https://github.com/Linuxfabrik/lfops/tree/main/roles/core_dumps): `setup_basic__skip_core_dumps`
 * [systemd_journald](https://github.com/Linuxfabrik/lfops/tree/main/roles/systemd_journald): `setup_basic__skip_systemd_journald`
-* [hostname](https://github.com/Linuxfabrik/lfops/tree/main/roles/hostname): `setup_basic__skip_hostname`
 * [timezone](https://github.com/Linuxfabrik/lfops/tree/main/roles/timezone): `setup_basic__skip_timezone`
 * [logrotate](https://github.com/Linuxfabrik/lfops/tree/main/roles/logrotate): `setup_basic__skip_logrotate`
 * [rsyslog](https://github.com/Linuxfabrik/lfops/tree/main/roles/rsyslog): `setup_basic__skip_rsyslog`
@@ -1068,10 +1081,6 @@ Calls the following roles (in order):
 * [sshd](https://github.com/Linuxfabrik/lfops/tree/main/roles/sshd): `setup_basic__skip_sshd`
 * [login](https://github.com/Linuxfabrik/lfops/tree/main/roles/login): `setup_basic__skip_login`
 * [firewall](https://github.com/Linuxfabrik/lfops/tree/main/roles/firewall): `setup_basic__skip_firewall`
-* [mailx](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailx): `setup_basic__skip_mailx`
-* [postfix](https://github.com/Linuxfabrik/lfops/tree/main/roles/postfix): `setup_basic__skip_postfix`
-* [mailto_root](https://github.com/Linuxfabrik/lfops/tree/main/roles/mailto_root): `setup_basic__skip_mailto_root`
-* [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot): `setup_basic__skip_schedule_reboot`
 * [system_update](https://github.com/Linuxfabrik/lfops/tree/main/roles/system_update): `setup_basic__skip_system_update`
 * [python_venv](https://github.com/Linuxfabrik/lfops/tree/main/roles/python_venv): `setup_basic__skip_python_venv`
 * [duplicity](https://github.com/Linuxfabrik/lfops/tree/main/roles/duplicity): `setup_basic__skip_duplicity`

--- a/playbooks/crypto_policy.yml
+++ b/playbooks/crypto_policy.yml
@@ -18,6 +18,26 @@
 
   roles:
 
+    - role: 'linuxfabrik.lfops.postfix'
+      postfix__aliases__dependent_var: '{{
+          mailto_root__postfix__aliases__dependent_var
+        }}'
+      postfix__sender_canonicals__dependent_var: '{{
+          mailto_root__postfix__sender_canonicals__dependent_var
+        }}'
+      when:
+        - 'not crypto_policy__skip_postfix | d(false)'
+
+    - role: 'linuxfabrik.lfops.mailto_root'
+      when:
+        - 'not crypto_policy__skip_mailto_root | d(false)'
+
+    # deployed before the crypto_policy role, so the schedule-reboot command is in place when a
+    # changed crypto policy requests a reboot
+    - role: 'linuxfabrik.lfops.schedule_reboot'
+      when:
+        - 'not crypto_policy__skip_schedule_reboot | d(false)'
+
     - role: 'linuxfabrik.lfops.crypto_policy'
 
 

--- a/playbooks/kernel_modules.yml
+++ b/playbooks/kernel_modules.yml
@@ -18,6 +18,26 @@
 
   roles:
 
+    - role: 'linuxfabrik.lfops.postfix'
+      postfix__aliases__dependent_var: '{{
+          mailto_root__postfix__aliases__dependent_var
+        }}'
+      postfix__sender_canonicals__dependent_var: '{{
+          mailto_root__postfix__sender_canonicals__dependent_var
+        }}'
+      when:
+        - 'not kernel_modules__skip_postfix | d(false)'
+
+    - role: 'linuxfabrik.lfops.mailto_root'
+      when:
+        - 'not kernel_modules__skip_mailto_root | d(false)'
+
+    # deployed before the kernel_modules role, so the schedule-reboot command is in place when a
+    # changed module blocklist requests a reboot
+    - role: 'linuxfabrik.lfops.schedule_reboot'
+      when:
+        - 'not kernel_modules__skip_schedule_reboot | d(false)'
+
     - role: 'linuxfabrik.lfops.kernel_modules'
 
 

--- a/playbooks/selinux.yml
+++ b/playbooks/selinux.yml
@@ -22,6 +22,26 @@
       when:
         - 'not selinux__skip_policycoreutils | d(false)'
 
+    - role: 'linuxfabrik.lfops.postfix'
+      postfix__aliases__dependent_var: '{{
+          mailto_root__postfix__aliases__dependent_var
+        }}'
+      postfix__sender_canonicals__dependent_var: '{{
+          mailto_root__postfix__sender_canonicals__dependent_var
+        }}'
+      when:
+        - 'not selinux__skip_postfix | d(false)'
+
+    - role: 'linuxfabrik.lfops.mailto_root'
+      when:
+        - 'not selinux__skip_mailto_root | d(false)'
+
+    # deployed before the selinux role, so the schedule-reboot command is in place when a
+    # SELinux state change requests a reboot
+    - role: 'linuxfabrik.lfops.schedule_reboot'
+      when:
+        - 'not selinux__skip_schedule_reboot | d(false)'
+
     - role: 'linuxfabrik.lfops.selinux'
 
 

--- a/playbooks/setup_basic.yml
+++ b/playbooks/setup_basic.yml
@@ -37,6 +37,48 @@
         - 'ansible_facts["os_family"] == "RedHat"'
         - 'not setup_basic__skip_repo_epel | d(false)'
 
+    # === Identity ===
+    # ahead of every role that renders the host's name into a configuration file.
+    # ansible.builtin.hostname returns the new name as ansible_facts, so a role running after it
+    # sees the final ansible_facts["nodename"], while one running before it renders the name the
+    # host booted with and rewrites the file on the next run. mailto_root builds its sender
+    # canonical from that fact, and schedule_reboot its Icinga host name.
+    - role: 'linuxfabrik.lfops.hostname'
+      when:
+        - 'not setup_basic__skip_hostname | d(false)'
+
+    # === Mailing ===
+    - role: 'linuxfabrik.lfops.mailx'
+      when:
+        - 'not setup_basic__skip_mailx | d(false)'
+
+    - role: 'linuxfabrik.lfops.postfix'
+      postfix__aliases__dependent_var: '{{
+          mailto_root__postfix__aliases__dependent_var
+        }}'
+      postfix__sender_canonicals__dependent_var: '{{
+          mailto_root__postfix__sender_canonicals__dependent_var
+        }}'
+      when:
+        - 'not setup_basic__skip_postfix | d(false)'
+
+    - role: 'linuxfabrik.lfops.mailto_root'
+      when:
+        - 'not setup_basic__skip_mailto_root | d(false)'
+
+    # === Reboots ===
+    # ahead of every role that can request a reboot, so that /usr/local/sbin/schedule-reboot is
+    # already on the host when one of them changes something that only takes effect on the next
+    # boot. The security roles below are three such roles (crypto_policy, kernel_modules,
+    # selinux). Deployed later, they would only ever report the pending reboot to the operator:
+    # they file the request on the run that makes the change, and by the next run there is
+    # nothing left to change. The mailing section above it comes first in turn, because
+    # schedule_reboot takes the addresses for its notification from mailto_root and delivers it
+    # with the sendmail that postfix provides.
+    - role: 'linuxfabrik.lfops.schedule_reboot'
+      when:
+        - 'not setup_basic__skip_schedule_reboot | d(false)'
+
     # === Security ===
     - role: 'linuxfabrik.lfops.crypto_policy'
       when:
@@ -72,10 +114,6 @@
     - role: 'linuxfabrik.lfops.systemd_journald'
       when:
         - 'not setup_basic__skip_systemd_journald | d(false)'
-
-    - role: 'linuxfabrik.lfops.hostname'
-      when:
-        - 'not setup_basic__skip_hostname | d(false)'
 
     - role: 'linuxfabrik.lfops.timezone'
       when:
@@ -173,31 +211,7 @@
         - 'not setup_basic__skip_firewall | d(false)'
 
 
-    # === Mailing ===
-    - role: 'linuxfabrik.lfops.mailx'
-      when:
-        - 'not setup_basic__skip_mailx | d(false)'
-
-    - role: 'linuxfabrik.lfops.postfix'
-      postfix__aliases__dependent_var: '{{
-          mailto_root__postfix__aliases__dependent_var
-        }}'
-      postfix__sender_canonicals__dependent_var: '{{
-          mailto_root__postfix__sender_canonicals__dependent_var
-        }}'
-      when:
-        - 'not setup_basic__skip_postfix | d(false)'
-
-    - role: 'linuxfabrik.lfops.mailto_root'
-      when:
-        - 'not setup_basic__skip_mailto_root | d(false)'
-
-
     # === Automatic updates ===
-    - role: 'linuxfabrik.lfops.schedule_reboot'
-      when:
-        - 'not setup_basic__skip_schedule_reboot | d(false)'
-
     - role: 'linuxfabrik.lfops.system_update'
       when:
         - 'not setup_basic__skip_system_update | d(false)'

--- a/roles/bootloader/tasks/main.yml
+++ b/roles/bootloader/tasks/main.yml
@@ -22,23 +22,12 @@
     when:
       - 'ansible_facts["os_family"] == "RedHat"'
 
-  - name: 'stat /usr/local/sbin/schedule-reboot'
-    ansible.builtin.stat:
-      path: '/usr/local/sbin/schedule-reboot'
-    register: '__bootloader__schedule_reboot_stat_result'
-
-  # a precondition, not a result: the host cannot perform the reboot this mode asks of it, so the
-  # run is refused before the boot entries are written rather than after. Deliberately not gated
-  # on whether this run changes anything, so the contradiction surfaces on every run instead of
-  # on the one run that happens to need a reboot.
-  - name: 'Assert that the schedule-reboot mechanism is deployed'
-    ansible.builtin.assert:
-      that:
-        - '__bootloader__schedule_reboot_stat_result["stat"]["exists"] | bool'
-      quiet: true
-      fail_msg: 'lfops__reboot_now is set, but /usr/local/sbin/schedule-reboot is missing. Run the schedule_reboot role, or unset the variable and reboot the host yourself.'
-    when:
-      - 'lfops__reboot_now | d(false) | bool'
+  # a precondition, not a result: the host cannot perform the reboot lfops__reboot_now asks of it,
+  # so the run is refused before the boot entries are written rather than after.
+  - name: 'Assert that a reboot is possible'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'assert-reboot-possible.yml'
 
   tags:
     # use 'always' so the validation runs even when other roles reference these variables.
@@ -72,84 +61,15 @@
   - name: 'Perform platform specific tasks'
     ansible.builtin.include_tasks: '{{ ansible_facts["os_family"] }}.yml'
 
-  # absolute path on purpose: the default sudoers of the Red Hat family sets
-  # `secure_path = /sbin:/bin:/usr/sbin:/usr/bin`, which leaves /usr/local/sbin out, so the bare
-  # command name is not found under `become: true`. Verified against sudo on Rocky 9.
-  - name: '/usr/local/sbin/schedule-reboot bootloader "kernel command line changed"'
-    ansible.builtin.command:
-      argv:
-        - '/usr/local/sbin/schedule-reboot'
-        - 'bootloader'
-        - 'kernel command line changed'
-    register: '__bootloader__schedule_reboot_result'
-    changed_when: '__bootloader__schedule_reboot_result["rc"] == 0'
+  - name: 'Request a reboot'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'request-reboot.yml'
+    vars:
+      shared__reboot_reason: 'bootloader'
+      shared__reboot_detail: 'kernel command line changed'
     when:
       - '__bootloader__reboot_needed | bool'
-      - 'not (lfops__reboot_now | d(false) | bool)'
-      - '__bootloader__schedule_reboot_stat_result["stat"]["exists"] | bool'
-
-  # --now files the same request and additionally starts the actor, which mails the
-  # administrators, sets the Icinga downtime, waits out the grace period and reboots. That drops
-  # the connection, so the task cannot be waited on. Killing the async wrapper does not stop the
-  # systemd unit, so the reboot happens either way.
-  - name: '/usr/local/sbin/schedule-reboot --now bootloader "kernel command line changed"'
-    ansible.builtin.command:
-      argv:
-        - '/usr/local/sbin/schedule-reboot'
-        - '--now'
-        - 'bootloader'
-        - 'kernel command line changed'
-    async: 1
-    poll: 0 # fire and forget: the reboot drops the connection, do not wait on it
-    changed_when: true # with poll: 0 the result is the async handle, not the command's rc
-    when:
-      - '__bootloader__reboot_needed | bool'
-      - 'lfops__reboot_now | d(false) | bool'
-
-  # wait for the host to be gone before waiting for it to return, instead of assuming it went
-  # down within a fixed delay. do-reboot mails the administrators and calls the Icinga API before
-  # it sleeps the grace period, so the moment the host actually goes down is not bounded: a slow
-  # sendmail or an unreachable Icinga endpoint delays it. Without this task the connection check
-  # below can succeed against the still-running host, report the reboot as done and let the play
-  # continue into a host that goes down moments later.
-  - name: 'Wait for the host to go down'
-    ansible.builtin.wait_for:
-      host: '{{ ansible_host | d(inventory_hostname) }}'
-      port: '{{ ansible_port | d(22) }}'
-      state: 'stopped'
-      timeout: '{{ (schedule_reboot__reboot_grace_period | d(60) | int) + 300 }}'
-    delegate_to: 'localhost'
-    become: false
-    when:
-      - '__bootloader__reboot_needed | bool'
-      - 'lfops__reboot_now | d(false) | bool'
-
-  # without this, every role after this one in the play runs against a host that is going down
-  - name: 'Wait for the host to come back after the reboot'
-    ansible.builtin.wait_for_connection:
-      delay: 5
-      sleep: 5
-      timeout: 300
-    when:
-      - '__bootloader__reboot_needed | bool'
-      - 'lfops__reboot_now | d(false) | bool'
-
-  - name: 'Report that a manual reboot is required'
-    ansible.builtin.debug:
-      msg: '{{ __bootloader__end_of_play_message }}'
-    when:
-      - '__bootloader__reboot_needed | bool'
-      - 'not __bootloader__schedule_reboot_stat_result["stat"]["exists"] | bool'
-
-  # printed again as one block above the PLAY RECAP, see roles/shared/tasks/print-messages.yml.
-  # The inline message above stays for plays outside this collection, which do not import the
-  # printer in their post_tasks.
-  - name: 'Collect the message for the end of the play'
-    ansible.builtin.set_fact:
-      __shared__end_of_play_messages: '{{ __shared__end_of_play_messages | d([]) + [__bootloader__end_of_play_message] }}'
-    when:
-      - '__bootloader__reboot_needed | bool'
-      - 'not __bootloader__schedule_reboot_stat_result["stat"]["exists"] | bool'
 
   tags:
     - 'bootloader'

--- a/roles/bootloader/vars/main.yml
+++ b/roles/bootloader/vars/main.yml
@@ -41,8 +41,3 @@ __bootloader__current_args: "{{
     | map('regex_replace', '\"', ' ')
     | list
   }}"
-
-# Collected in __shared__end_of_play_messages and printed once at the end of the play, see
-# roles/shared/tasks/print-messages.yml. Kept in one place because the role both prints it inline
-# and appends it there.
-__bootloader__end_of_play_message: 'bootloader: The kernel command line has changed. Please reboot the server manually to apply it.'

--- a/roles/crypto_policy/README.md
+++ b/roles/crypto_policy/README.md
@@ -6,11 +6,28 @@ On Red Hat-family systems, `update-crypto-policies` is a system-wide switch that
 *Available since LFOps `2.0.0`.*
 
 
+## How the Role Behaves
+
+`update-crypto-policies --set` rewrites the configuration the crypto libraries read, but every process that is already running keeps the algorithm set it started with. The host is therefore in a mixed state until it is restarted, which is what the command itself says: "System-wide crypto policies are applied on application start-up. It is recommended to restart the system for the change of policies to fully take place."
+
+When the [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot) mechanism is deployed, a changed policy therefore requests a reboot at the next maintenance window (spool entry `crypto_policy`). Without it, the role only prints a message and leaves the reboot to the operator. A run against a host that already carries the configured policy changes nothing and requests nothing.
+
+`lfops__reboot_now` makes the role reboot in the same run instead of waiting for the window. The reboot still goes through the same mechanism, so the notification mail, the Icinga downtime and the grace period all apply, and a reboot another role requested earlier in the run is carried out together with this one. The role then waits for the host to come back before the play continues. Have a look at the [README](https://github.com/Linuxfabrik/lfops/blob/main/README.md#lfops__reboot_now). With the variable set on a host where the `schedule_reboot` mechanism is missing, the run aborts rather than reporting a reboot it cannot perform.
+
+
+## Dependent Roles
+
+Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/README.md) that installs this role runs these for you. Optional ones can be disabled via the playbook's skip variables.
+
+* Optional: the reboot mechanism should be in place (role: [linuxfabrik.lfops.schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot)), so a changed policy reboots the host at the maintenance window instead of waiting for a manual reboot.
+
+
 ## Tags
 
 `crypto_policy`
 
 * Sets the system crypto policy.
+* Requests a reboot when the policy changed, or performs it in the same run when `lfops__reboot_now` is set.
 * Triggers: none.
 
 

--- a/roles/crypto_policy/tasks/main.yml
+++ b/roles/crypto_policy/tasks/main.yml
@@ -1,5 +1,18 @@
 - block:
 
+  # a precondition, not a result: the host cannot perform the reboot lfops__reboot_now asks of it,
+  # so the run is refused before the policy is switched rather than after.
+  - name: 'Assert that a reboot is possible'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'assert-reboot-possible.yml'
+
+  tags:
+    - 'always'
+
+
+- block:
+
   - name: 'Deploy /etc/crypto-policies/policies/modules/*.pmod'
     ansible.builtin.template:
       backup: true
@@ -24,7 +37,23 @@
 
   - name: 'update-crypto-policies --set "{{ crypto_policy__policy }}"'
     ansible.builtin.command: 'update-crypto-policies --set "{{ crypto_policy__policy }}"'
+    register: '__crypto_policy__set_result'
+    changed_when: '__crypto_policy__set_result["rc"] == 0'
     when: 'crypto_policy__current_policy_result["stdout"] != crypto_policy__policy'
+
+  # "Note: System-wide crypto policies are applied on application start-up. It is recommended to
+  # restart the system for the change of policies to fully take place." is what the command itself
+  # prints. Everything already running keeps the old policy until it is restarted, so the host is
+  # in a mixed state until the reboot. Verified against crypto-policies 20260224 on Rocky 9.8.
+  - name: 'Request a reboot'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'request-reboot.yml'
+    vars:
+      shared__reboot_reason: 'crypto_policy'
+      shared__reboot_detail: 'system-wide crypto policy changed'
+    when:
+      - '__crypto_policy__set_result is changed'
 
   tags:
     - 'crypto_policy'

--- a/roles/kernel_modules/README.md
+++ b/roles/kernel_modules/README.md
@@ -11,8 +11,17 @@ This role disables kernel modules by deploying `/etc/modprobe.d/linuxfabrik-kern
 * For each module, the role writes an `install <module> /bin/true` line. This prevents the module from being loaded, both automatically (e.g. on device hotplug) and via a manual `modprobe`. This is stronger than `blacklist`, which only prevents automatic loading.
 * By default the role disables the modules that the CIS Benchmarks recommend disabling and that are safe to disable on a typical server: the FireWire storage stack (`firewire-core`, `firewire-ohci`, `firewire-sbp2`), the legacy / obscure filesystems `cramfs`, `freevxfs`, `hfs`, `hfsplus` and `jffs2`, and the uncommon network protocols `atm`, `can`, `dccp`, `rds`, `sctp` and `tipc`.
 * Some modules that CIS also lists are **not** disabled by default, because doing so would break common workloads: `overlay` (used by Docker / Podman), `squashfs` (used by snap on Ubuntu and by live / appliance images), `udf` (mounting DVDs / UDF images) and `usb-storage` (USB flash drives). Disable any of these explicitly where wanted.
-* A module that is already loaded when the role runs stays loaded until the next reboot. Reboot the host (or unload the module manually with `modprobe -r`) to fully apply the change.
+* A module that is already loaded when the role runs stays loaded until the next reboot. When the configuration changed and at least one of the blocked modules is loaded, the role requests a reboot at the next maintenance window through the [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot) mechanism (spool entry `kernel_modules`); without that mechanism it only prints a message and leaves the reboot to the operator. Unloading the module by hand with `modprobe -r` applies the change without a reboot. A host that has none of the blocked modules loaded is already in the target state and gets no request, which is why deploying the defaults to a fresh host does not reboot it.
 * To re-enable a module that the role disables by default, set its `enabled` to `true` in your inventory.
+* Only the run that changes the configuration requests the reboot. A later run finds the file already correct and stays quiet, even while the modules are still loaded and the reboot is still pending.
+* `lfops__reboot_now` makes the role reboot in the same run instead of waiting for the window. The reboot still goes through the same mechanism, so the notification mail, the Icinga downtime and the grace period all apply, and a reboot another role requested earlier in the run is carried out together with this one. The role then waits for the host to come back before the play continues. Have a look at the [README](https://github.com/Linuxfabrik/lfops/blob/main/README.md#lfops__reboot_now). With the variable set on a host where the `schedule_reboot` mechanism is missing, the run aborts rather than reporting a reboot it cannot perform.
+
+
+## Dependent Roles
+
+Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/README.md) that installs this role runs these for you. Optional ones can be disabled via the playbook's skip variables.
+
+* Optional: the reboot mechanism should be in place (role: [linuxfabrik.lfops.schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot)), so blocking a module that is still loaded reboots the host at the maintenance window instead of waiting for a manual reboot.
 
 
 ## Tags
@@ -20,6 +29,7 @@ This role disables kernel modules by deploying `/etc/modprobe.d/linuxfabrik-kern
 `kernel_modules`
 
 * Deploys the modprobe configuration that disables the configured kernel modules.
+* Requests a reboot when a module that is still loaded got blocked, or performs it in the same run when `lfops__reboot_now` is set.
 * Triggers: none.
 
 

--- a/roles/kernel_modules/tasks/main.yml
+++ b/roles/kernel_modules/tasks/main.yml
@@ -1,5 +1,18 @@
 - block:
 
+  # a precondition, not a result: the host cannot perform the reboot lfops__reboot_now asks of it,
+  # so the run is refused before the modprobe configuration is written rather than after.
+  - name: 'Assert that a reboot is possible'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'assert-reboot-possible.yml'
+
+  tags:
+    - 'always'
+
+
+- block:
+
   - name: 'Combined kernel modules'
     ansible.builtin.debug:
       var: 'kernel_modules__modules__combined_var'
@@ -15,6 +28,28 @@
       owner: 'root'
       group: 'root'
       mode: 0o644
+    register: '__kernel_modules__conf_result'
+
+  - name: 'cat /proc/modules'
+    ansible.builtin.slurp:
+      src: '/proc/modules'
+    register: '__kernel_modules__proc_modules_result'
+    when:
+      - '__kernel_modules__conf_result is changed'
+
+  # Only the run that changes the configuration asks for the reboot. A later run finds the file
+  # already correct and stays quiet, even while the modules are still loaded and the reboot is
+  # still pending: the spool file lives in /run and outlives those runs.
+  - name: 'Request a reboot'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'request-reboot.yml'
+    vars:
+      shared__reboot_reason: 'kernel_modules'
+      shared__reboot_detail: 'blocked kernel modules are still loaded ({{ __kernel_modules__loaded_blocked_module_names | join(", ") }})'
+    when:
+      - '__kernel_modules__conf_result is changed'
+      - '__kernel_modules__loaded_blocked_module_names | length > 0'
 
   tags:
     - 'kernel_modules'

--- a/roles/kernel_modules/vars/main.yml
+++ b/roles/kernel_modules/vars/main.yml
@@ -1,0 +1,33 @@
+# The modules the role blocks, in inventory order, using the same rule as the template that writes
+# the modprobe configuration: an entry is blocked unless its `enabled` is true. Reading `enabled`
+# through `map(attribute=..., default=false)` and `bool` keeps that rule identical to the
+# template's `not (item['enabled'] | d(false) | bool)`, including for an entry that carries no
+# `enabled` key at all.
+__kernel_modules__blocked_module_names: '{{
+    kernel_modules__modules__combined_var | map(attribute="name") | list
+    | zip(kernel_modules__modules__combined_var
+          | map(attribute="enabled", default=false) | map("bool") | list)
+    | rejectattr(1) | map(attribute=0) | list
+  }}'
+
+# The modules the running kernel has loaded, one per line of /proc/modules with the name in the
+# first space-separated field. /proc/modules spells every name with underscores, whatever modprobe
+# accepts on the command line ("firewire-core" is listed as "firewire_core"), so the blocked names
+# are normalised the same way before the two lists are compared.
+# Verified against Linux 5.14 on Rocky 9.8.
+#
+# split/first rather than regex_replace on purpose: in a single-quoted YAML scalar a backslash is
+# literal, so the "\S" of a character class would have to be written unescaped to survive into the
+# regex, which reads like a typo and invites the next person to "fix" it back into silence.
+__kernel_modules__loaded_module_names: '{{
+    (__kernel_modules__proc_modules_result["content"] | d("") | b64decode).splitlines()
+    | map("split", " ") | map("first") | list
+  }}'
+
+# Blocking a module keeps it from being loaded from now on, but one that is already loaded stays
+# loaded until the host reboots. Only then is the change actually in effect, so only then is a
+# reboot worth asking for: a host that never loaded any of them is already in the target state.
+__kernel_modules__loaded_blocked_module_names: '{{
+    __kernel_modules__blocked_module_names | map("replace", "-", "_") | list
+    | intersect(__kernel_modules__loaded_module_names)
+  }}'

--- a/roles/kernel_settings/tasks/main.yml
+++ b/roles/kernel_settings/tasks/main.yml
@@ -27,17 +27,5 @@
       kernel_settings_transparent_hugepages: '{{ kernel_settings__transparent_hugepages__combined_var }}' # noqa var-naming[pattern]
       kernel_settings_transparent_hugepages_defrag: '{{ kernel_settings__transparent_hugepages_defrag__combined_var }}' # noqa var-naming[pattern]
 
-  - ansible.builtin.debug:
-      msg: '{{ __kernel_settings__end_of_play_message }}'
-    when: 'kernel_settings_reboot_required is defined and kernel_settings_reboot_required | bool'
-
-  # printed again as one block above the PLAY RECAP, see roles/shared/tasks/print-messages.yml.
-  # The inline message above stays for plays outside this collection, which do not import the
-  # printer in their post_tasks.
-  - name: 'Collect the message for the end of the play'
-    ansible.builtin.set_fact:
-      __shared__end_of_play_messages: '{{ __shared__end_of_play_messages | d([]) + [__kernel_settings__end_of_play_message] }}'
-    when: 'kernel_settings_reboot_required is defined and kernel_settings_reboot_required | bool'
-
   tags:
     - 'kernel_settings'

--- a/roles/kernel_settings/vars/main.yml
+++ b/roles/kernel_settings/vars/main.yml
@@ -1,4 +1,0 @@
-# Collected in __shared__end_of_play_messages and printed once at the end of the play, see
-# roles/shared/tasks/print-messages.yml. Kept in one place because the role both prints it inline
-# and appends it there.
-__kernel_settings__end_of_play_message: 'kernel_settings: Please restart the server manually to apply new kernel settings.'

--- a/roles/selinux/README.md
+++ b/roles/selinux/README.md
@@ -21,12 +21,22 @@ Compiling the same source twice yields a byte-identical policy package, so the r
 
 Under `--check` the role compiles and compares as usual, since that only writes to the temporary directory. It cannot report the resulting `semodule --install` though: Ansible skips command tasks in check mode.
 
+Switching SELinux on or off is the one change the running kernel cannot perform, so it only takes effect on the next boot. The role writes `/etc/selinux/config` and, when the [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot) mechanism is deployed, requests a reboot at the next maintenance window (spool entry `selinux`). Without it, the role only prints a message and leaves the reboot to the operator. Switching between `enforcing` and `permissive` needs no reboot and requests none. Only the run that rewrites the configuration files the request; a later run stays quiet while the reboot is still pending.
+
+`lfops__reboot_now` makes the role reboot in the same run instead of waiting for the window. The reboot still goes through the same mechanism, so the notification mail, the Icinga downtime and the grace period all apply, and a reboot another role requested earlier in the run is carried out together with this one. The role then waits for the host to come back before the play continues. Have a look at the [README](https://github.com/Linuxfabrik/lfops/blob/main/README.md#lfops__reboot_now). With the variable set on a host where the `schedule_reboot` mechanism is missing, the run aborts rather than reporting a reboot it cannot perform.
+
+
+## Known Limitations
+
+* A change of `selinux__policy` (the policy type, e.g. `targeted` to `mls`) also needs a reboot, and a full relabel of the file system on top, but it does not request one. `ansible.posix.selinux` reports the policy change as a change without reporting a reboot as required, and the role does not second-guess it. Reboot and relabel such a host yourself.
+
 
 ## Dependent Roles
 
 Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/README.md) that installs this role runs these for you. Optional ones can be disabled via the playbook's skip variables.
 
 * The SELinux python bindings must be installed (role: [linuxfabrik.lfops.policycoreutils](https://github.com/Linuxfabrik/lfops/tree/main/roles/policycoreutils)).
+* Optional: the reboot mechanism should be in place (role: [linuxfabrik.lfops.schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot)), so a state change reboots the host at the maintenance window instead of waiting for a manual reboot.
 
 
 ## Tags
@@ -64,6 +74,7 @@ Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/RE
 `selinux:setenforce`
 
 * `setenforce ...`.
+* Requests a reboot when SELinux has to be switched on or off, or performs it in the same run when `lfops__reboot_now` is set.
 * Triggers: none.
 
 `selinux:setsebool`

--- a/roles/selinux/tasks/main.yml
+++ b/roles/selinux/tasks/main.yml
@@ -25,6 +25,20 @@
 
 - block:
 
+  # a precondition, not a result: the host cannot perform the reboot lfops__reboot_now asks of it,
+  # so the run is refused before /etc/selinux/config is rewritten rather than after.
+  - name: 'Assert that a reboot is possible'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'assert-reboot-possible.yml'
+
+  tags:
+    # use 'always' so the check runs whichever section of the role the operator selected.
+    - 'always'
+
+
+- block:
+
   - name: 'Combined SELinux modules:'
     ansible.builtin.debug:
       var: 'selinux__modules__combined_var'
@@ -293,6 +307,23 @@
     ansible.posix.selinux:
       policy: '{{ selinux__policy }}'
       state: '{{ selinux__state }}'
+    register: '__selinux__setenforce_result'
+
+  # The module reports reboot_required whenever SELinux has to be switched on or off, which the
+  # running kernel cannot do. It keeps reporting it until the host has actually rebooted, so the
+  # request is additionally gated on this run having changed something: the run that rewrites
+  # /etc/selinux/config files the request, every run after it stays quiet while the reboot is
+  # still pending. The spool file lives in /run and outlives those runs.
+  - name: 'Request a reboot'
+    ansible.builtin.include_role:
+      name: 'shared'
+      tasks_from: 'request-reboot.yml'
+    vars:
+      shared__reboot_reason: 'selinux'
+      shared__reboot_detail: 'SELinux state changed'
+    when:
+      - '__selinux__setenforce_result is changed'
+      - '__selinux__setenforce_result["reboot_required"] | d(false) | bool'
 
   tags:
     - 'selinux'

--- a/roles/shared/README.md
+++ b/roles/shared/README.md
@@ -28,6 +28,15 @@ This role bundles helper tasks reused across other LFOps roles and playbooks. It
 * Loads LFOps-wide platform variables from the shared role's *own* `vars/<name>.yml` files (`role_path`, not the calling role), using the same least-to-most-specific order as `platform-variables.yml`. Imported in every playbook's `pre_tasks` so the variables are available to all roles in the play.
 * Parameters: none.
 
+`assert-reboot-possible.yml` and `request-reboot.yml`
+
+* The two halves of the reboot pattern, see the "Reboots" section of the [CONTRIBUTING.md](https://github.com/Linuxfabrik/lfops/blob/main/CONTRIBUTING.md). `assert-reboot-possible.yml` belongs in the calling role's validation block: it refuses `lfops__reboot_now` on a host without `/usr/local/sbin/schedule-reboot` before the role writes anything, and registers the stat result the other file reads. `request-reboot.yml` files the reboot request, performs the reboot right away when `lfops__reboot_now` is set, or reports the pending reboot to the operator when the mechanism is not deployed. Include it gated on the calling role's own "a reboot is needed" condition.
+* Parameters of `assert-reboot-possible.yml`: none.
+* Parameters of `request-reboot.yml`:
+
+    * `shared__reboot_reason`: Mandatory. Spool file name, by convention the role name.
+    * `shared__reboot_detail`: Mandatory. What changed, in lower case. Goes into the notification mail and into the message the operator sees.
+
 `clone-lib-repo.yml`
 
 * Clones the [Linuxfabrik Python Libraries](https://github.com/Linuxfabrik/lib) to `/tmp/ansible.lib-repo` on the Ansible controller (`delegate_to: localhost`, serialized with `throttle: 1`, `--check`-safe). Includes a rescue path that wipes the directory and retries on failure (e.g. when an existing checkout is on a different ref).

--- a/roles/shared/tasks/assert-reboot-possible.yml
+++ b/roles/shared/tasks/assert-reboot-possible.yml
@@ -1,0 +1,28 @@
+# Refuses lfops__reboot_now on a host that cannot perform the reboot, and registers the stat
+# result that request-reboot.yml reads later.
+#
+# Import this from the calling role's validation block, tagged 'always', so the contradiction is
+# decided before the role writes anything. Deliberately not gated on whether this run changes
+# anything: the check has to surface on every run, not only on the one run that happens to need a
+# reboot, which is the run that can least afford to abort halfway through.
+#
+#   - name: 'Assert that a reboot is possible'
+#     ansible.builtin.include_role:
+#       name: 'shared'
+#       tasks_from: 'assert-reboot-possible.yml'
+#
+# Parameters: none.
+
+- name: 'stat /usr/local/sbin/schedule-reboot'
+  ansible.builtin.stat:
+    path: '/usr/local/sbin/schedule-reboot'
+  register: '__shared__schedule_reboot_stat_result'
+
+- name: 'Assert that the schedule-reboot mechanism is deployed'
+  ansible.builtin.assert:
+    that:
+      - '__shared__schedule_reboot_stat_result["stat"]["exists"] | bool'
+    quiet: true
+    fail_msg: 'lfops__reboot_now is set, but /usr/local/sbin/schedule-reboot is missing. Run the schedule_reboot role, or unset the variable and reboot the host yourself.'
+  when:
+    - 'lfops__reboot_now | d(false) | bool'

--- a/roles/shared/tasks/request-reboot.yml
+++ b/roles/shared/tasks/request-reboot.yml
@@ -1,0 +1,97 @@
+# Files a reboot request with the schedule_reboot mechanism, performs the reboot right away when
+# lfops__reboot_now is set, or reports the pending reboot to the operator when the mechanism is not
+# deployed on the host.
+#
+# Include it from the role that made the change, gated on that role's own "a reboot is needed"
+# condition. Nothing here is gated on it again, so an unnecessary include is a skipped include, not
+# a run of no-op tasks:
+#
+#   - name: 'Request a reboot'
+#     ansible.builtin.include_role:
+#       name: 'shared'
+#       tasks_from: 'request-reboot.yml'
+#     vars:
+#       shared__reboot_reason: 'example'
+#       shared__reboot_detail: 'kernel command line changed'
+#     when:
+#       - '__example__reboot_needed | bool'
+#
+# assert-reboot-possible.yml has to run in the calling role's validation block beforehand. It
+# registers __shared__schedule_reboot_stat_result, which the tasks below read.
+#
+# Parameters:
+#   shared__reboot_reason: Mandatory. Spool file name, by convention the role name.
+#   shared__reboot_detail: Mandatory. What changed, in lower case. Goes into the notification mail
+#                          and into the message the operator sees.
+
+# absolute path on purpose: the default sudoers of the Red Hat family sets
+# `secure_path = /sbin:/bin:/usr/sbin:/usr/bin`, which leaves /usr/local/sbin out, so the bare
+# command name is not found under `become: true`. Verified against sudo on Rocky 9.
+- name: '/usr/local/sbin/schedule-reboot {{ shared__reboot_reason }} "{{ shared__reboot_detail }}"'
+  ansible.builtin.command:
+    argv:
+      - '/usr/local/sbin/schedule-reboot'
+      - '{{ shared__reboot_reason }}'
+      - '{{ shared__reboot_detail }}'
+  register: '__shared__schedule_reboot_result'
+  changed_when: '__shared__schedule_reboot_result["rc"] == 0'
+  when:
+    - 'not (lfops__reboot_now | d(false) | bool)'
+    - '__shared__schedule_reboot_stat_result["stat"]["exists"] | bool'
+
+# --now files the same request and additionally starts the actor, which mails the administrators,
+# sets the Icinga downtime, waits out the grace period and reboots. That drops the connection, so
+# the task cannot be waited on. Killing the async wrapper does not stop the systemd unit, so the
+# reboot happens either way.
+- name: '/usr/local/sbin/schedule-reboot --now {{ shared__reboot_reason }} "{{ shared__reboot_detail }}"'
+  ansible.builtin.command:
+    argv:
+      - '/usr/local/sbin/schedule-reboot'
+      - '--now'
+      - '{{ shared__reboot_reason }}'
+      - '{{ shared__reboot_detail }}'
+  async: 1
+  poll: 0 # fire and forget: the reboot drops the connection, do not wait on it
+  changed_when: true # with poll: 0 the result is the async handle, not the command's rc
+  when:
+    - 'lfops__reboot_now | d(false) | bool'
+
+# wait for the host to be gone before waiting for it to return, instead of assuming it went down
+# within a fixed delay. do-reboot mails the administrators and calls the Icinga API before it
+# sleeps the grace period, so the moment the host actually goes down is not bounded: a slow
+# sendmail or an unreachable Icinga endpoint delays it. Without this task the connection check
+# below can succeed against the still-running host, report the reboot as done and let the play
+# continue into a host that goes down moments later.
+- name: 'Wait for the host to go down'
+  ansible.builtin.wait_for:
+    host: '{{ ansible_host | d(inventory_hostname) }}'
+    port: '{{ ansible_port | d(22) }}'
+    state: 'stopped'
+    timeout: '{{ (schedule_reboot__reboot_grace_period | d(60) | int) + 300 }}'
+  delegate_to: 'localhost'
+  become: false
+  when:
+    - 'lfops__reboot_now | d(false) | bool'
+
+# without this, every role after this one in the play runs against a host that is going down
+- name: 'Wait for the host to come back after the reboot'
+  ansible.builtin.wait_for_connection:
+    delay: 5
+    sleep: 5
+    timeout: 300
+  when:
+    - 'lfops__reboot_now | d(false) | bool'
+
+- name: 'Report that a manual reboot is required'
+  ansible.builtin.debug:
+    msg: '{{ __shared__reboot_message }}'
+  when:
+    - 'not __shared__schedule_reboot_stat_result["stat"]["exists"] | bool'
+
+# printed again as one block above the PLAY RECAP, see print-messages.yml. The inline message above
+# stays for plays outside this collection, which do not import the printer in their post_tasks.
+- name: 'Collect the message for the end of the play'
+  ansible.builtin.set_fact:
+    __shared__end_of_play_messages: '{{ __shared__end_of_play_messages | d([]) + [__shared__reboot_message] }}'
+  when:
+    - 'not __shared__schedule_reboot_stat_result["stat"]["exists"] | bool'

--- a/roles/shared/vars/main.yml
+++ b/roles/shared/vars/main.yml
@@ -1,0 +1,6 @@
+# The message request-reboot.yml shows the operator when the schedule_reboot mechanism is not
+# deployed, and appends to __shared__end_of_play_messages. It lives here rather than in a set_fact
+# task so that both places read the same string without composing it twice. Jinja is evaluated
+# lazily, so the reference to the two request-reboot.yml parameters costs nothing in the playbooks
+# that import the shared role for something else.
+__shared__reboot_message: '{{ shared__reboot_reason | d("") }}: {{ shared__reboot_detail | d("") }}. Please reboot the server manually to apply it.'


### PR DESCRIPTION
## What

A role that changes something the running kernel cannot apply has to request a reboot. That logic lived in `roles/bootloader` as ~85 lines, and `CONTRIBUTING.md` told the next role to copy them. This factors it into two task files of the `shared` role and applies it to three more roles.

* `shared/tasks/assert-reboot-possible.yml` refuses `lfops__reboot_now` on a host without `/usr/local/sbin/schedule-reboot`, before the calling role writes anything.
* `shared/tasks/request-reboot.yml` files the request, reboots right away when `lfops__reboot_now` is set, or reports the pending reboot to the operator.

`roles/bootloader` is refactored onto them with no behaviour change; its reboot handling goes from ~85 lines to 9.

## The new consumers, and what each gates on

| role | requests a reboot when |
| --- | --- |
| `crypto_policy` | `update-crypto-policies --set` actually ran. Processes already running keep the old algorithm set until restarted, which is what the command itself says. |
| `kernel_modules` | the modprobe configuration changed **and** one of the blocked modules is in `/proc/modules`. Without the second half every fresh host would reboot for a default that changes nothing on it. |
| `selinux` | `ansible.posix.selinux` reports `changed` **and** `reboot_required`. The module keeps reporting `reboot_required` until the host has rebooted, so gating on it alone would re-request on every run and fail the idempotence step. |

`kernel_settings` loses its "please restart the server" message instead of gaining the pattern. Upstream `fedora.linux_system_roles.kernel_settings` sets `kernel_settings_reboot_required: false` unconditionally, with the comment *"reboot not currently used ... we now have a dedicated bootloader role"*, so our message was unreachable.

## `setup_basic` role order

`setup_basic` ran `crypto_policy`, `selinux` and `kernel_modules` at positions 4, 6 and 7, but deployed `schedule_reboot` only at 35. On a fresh host the three roles therefore found no `/usr/local/sbin/schedule-reboot` and could only report the pending reboot; the request was never filed, and no later run filed it either, because they request on the run that makes the change and by the next run there is nothing left to change.

The `# === Mailing ===` section and `schedule_reboot` now run ahead of `# === Security ===`. The mailing section has to come first in turn, because `schedule_reboot` takes its notification addresses from `mailto_root` and delivers through the `sendmail` that `postfix` provides. All three roles use only `ansible.builtin` modules and packages from the repositories set up above them, so nothing they need sits between the old and the new position. `system_update` still runs after `schedule_reboot`.

The `hostname` role moves up as well, into its own `# === Identity ===` section ahead of the mailing section. `mailto_root` builds its sender canonical from `ansible_facts["nodename"]`, and `ansible.builtin.hostname` returns the new name as `ansible_facts`, so a role running after `hostname` renders the final name while one running before it renders the name the host booted with. The old order was safe (`hostname` at 11, `postfix` at 33); moving `postfix` above `hostname` made the second run rewrite `/etc/postfix/canonical`, which the `idempotence` step caught. `schedule_reboot__icinga2_hostname` reads the same fact.

One consequence worth knowing: with `lfops__reboot_now` set, a fresh Red Hat host can now reboot three times in one `setup_basic` run, once per requesting role, because that variable reboots inline. The default windowed path is unaffected and still coalesces into a single reboot, since all three requests land in the same spool directory. Left as is for now.

## Breaking change

The `crypto_policy`, `kernel_modules` and `selinux` playbooks now run `postfix`, `mailto_root` and `schedule_reboot` before their own role. `schedule_reboot` defaults `schedule_reboot__mail_from` to `mailto_root__from` and aborts at role entry without it, which is why every existing consumer wires all three.

`mailto_root__from` and `mailto_root__to` therefore become mandatory for those three playbooks. A host set up with `setup_basic` already has both. To keep a playbook as it was, set `<playbook>__skip_postfix`, `<playbook>__skip_mailto_root` and `<playbook>__skip_schedule_reboot` to `true`.

## Testing

* All three `bootloader` Molecule scenarios pass, including `idempotence`. `bootloader/reboot_now` exercised the moved tasks for real: the VM went down in 6.9s and came back in 17.5s through `request-reboot.yml`.
* `crypto_policy` and `kernel_modules` were walked through every row of the behaviour table in a Rocky 9.8 container: request filed in `/run/schedule-reboot/` with the mechanism present, operator message plus end-of-play block without it, `lfops__reboot_now` aborting *before* the config is written on a host without the mechanism, and `changed=0` on the second run. Two roles in one play collect into a single block.
* The `selinux` gate was checked against all five outcomes of `ansible.posix.selinux` separately, since SELinux state cannot be exercised in a container (no `/etc/selinux/config`).
* `setup_basic` was run **scoped to the Red Hat family** (`LFOPS_TEST_TARGETS='rocky*'`, on `rocky8-vm`, `rocky9-vm`, `rocky10-vm`), which is also the only family where `crypto_policy` and `selinux` run at all. `converge` and `verify` pass. `schedule_reboot` deploys the CLI, then `crypto_policy` files its request (`changed` on all three hosts) while `Report that a manual reboot is required` is skipped, which is the exact inversion of the old behaviour.
* `idempotence` fails on four tasks, all in roles this PR does not touch:
    * `monitoring_plugins : dnf versionlock delete linuxfabrik-monitoring-plugins*` and `… add …`: bare `ansible.builtin.command` tasks without `changed_when`, so they report a change on every run by construction.
    * `firewall : systemctl start fwb.service` and `dnf_makecache : systemctl disable dnf-makecache.service`: `ansible.builtin.service` tasks whose requested state does not hold on the host.

  The scenario never reached `idempotence` before this PR, because `converge` always stopped on its Debian-family targets (see next point), so these four were hidden behind that failure. They are tracked in #353. None of the reboot tasks reports a change on the second pass: `crypto_policy`, `selinux` and `kernel_modules` stop requesting once the host is converged, as intended.
* The full 8-host `setup_basic` run cannot pass on this branch or on `main`: the 5 Debian-family targets fail in `fedora.linux_system_roles.network : Install packages` with `No package matching 'network-scripts' is available`. That is not a regression. `COMPATIBILITY.md` marks the `network` role `-` ("does not currently run") for Debian 12 and 13 and leaves the Ubuntu columns empty, but `setup_basic.yml` runs it with no `os_family` gate, unlike every other Red Hat-only role in that playbook. Worth its own commit; untouched here.
* `yamllint` clean. `ansible-playbook --syntax-check` 148/159, with the same 11 pre-existing failures as on `main` (the `ansible.mariadb` collection is not installed locally, and the `example` playbook references the fictional `repo_example` role).

## Not in this PR

* **No Molecule scenarios for the three new consumers.** `CONTRIBUTING.md` asks for a windowed scenario plus a destructive `reboot_now` sub-scenario per role; none of the three has any scenario today, so that is three new VM-based scenario pairs.

