### PR TITLE
feat(roles): add a central Icinga2 downtime API user and fix the downtime API URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **role:borg_local, role:schedule_reboot, role:tools**: The Icinga downtime around a backup or a reboot is set again when the deploying playbook does not run `icinga2_agent` itself, such as `bootloader`, `system_update` or `tools`, and the inventory only sets the mandatory `icinga2_agent__icinga2_master_cn`.
 * **role:fail2ban**: The `apache-botsearch`, `apache-fakegooglebot`, `apache-nohome` and `apache-noscript` jail templates can be deployed again. Using one of them aborted the run.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **role:borg_local, role:icinga2_master, role:nextcloud, role:schedule_reboot, role:tools**: `icinga2_master__downtime_api_user` creates an Icinga2 API user that may only schedule and remove downtimes, and the roles that set a downtime around a backup, a Nextcloud update or a reboot use it unless their own `*__icinga2_api_user_login` is set.
 * **role:crypto_policy, role:kernel_modules, role:selinux**: A change that only takes effect after a reboot requests one at the maintenance window instead of being left to the operator to notice: a switched crypto policy, a blocked kernel module that is still loaded, and switching SELinux on or off. Where the reboot mechanism is not deployed, the role reports the pending reboot as before. `lfops__reboot_now` performs it in the same run.
 * Every playbook prints the manual steps a run leaves to the operator as one block directly above the `PLAY RECAP`, collected from all roles of the play instead of scattered over its output. The roles keep printing their message where it occurs as well, so a role used outside this collection still reports it.
 * **role:bootloader**: New role that manages the kernel command line, for parameters that only take effect at boot time such as `psi=1`. Options are applied to every boot entry of the host, on the Red Hat family with `grubby` and on Debian and Ubuntu through a GRUB drop-in of its own. A changed command line requests a reboot at the maintenance window instead of rebooting right away, or applies it during the run when `lfops__reboot_now` is set, and a `--check` run reports what it would change without touching the host.
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **role:nextcloud**: `nextcloud-update` sets the Icinga downtime again, taking the API user from `icinga2_master__downtime_api_user` (see Added) instead of from the `system_update__icinga2_api_user_login` removed in v8.0.0.
 * **role:borg_local, role:schedule_reboot, role:tools**: The Icinga downtime around a backup or a reboot is set again when the deploying playbook does not run `icinga2_agent` itself, such as `bootloader`, `system_update` or `tools`, and the inventory only sets the mandatory `icinga2_agent__icinga2_master_cn`.
 * **role:fail2ban**: The `apache-botsearch`, `apache-fakegooglebot`, `apache-nohome` and `apache-noscript` jail templates can be deployed again. Using one of them aborted the run.
 

--- a/extensions/molecule/schedule_reboot/reboot/inventory/group_vars/systems_under_test.yml
+++ b/extensions/molecule/schedule_reboot/reboot/inventory/group_vars/systems_under_test.yml
@@ -16,10 +16,11 @@ schedule_reboot__mail_subject_prefix: '[molecule] '
 # the reconnect and make the check flap. The grace period itself is not under test here.
 schedule_reboot__reboot_grace_period: 0
 
-# Only the mandatory variable of the icinga2_agent role, which this playbook does not
-# run: the downtime request must reach the Icinga2 API all the same. verify.yml runs a
-# stand-in for the API on the host itself, hence localhost.
+# Only the central variables of the icinga2_agent and icinga2_master roles, neither of
+# which this playbook runs: the downtime request must reach the Icinga2 API, with these
+# credentials, all the same. verify.yml runs a stand-in for the API on the host itself,
+# hence localhost.
 icinga2_agent__icinga2_master_cn: 'localhost'
-schedule_reboot__icinga2_api_user_login:
+icinga2_master__downtime_api_user:
   username: 'molecule'
   password: 'linuxfabrik'

--- a/extensions/molecule/schedule_reboot/reboot/inventory/group_vars/systems_under_test.yml
+++ b/extensions/molecule/schedule_reboot/reboot/inventory/group_vars/systems_under_test.yml
@@ -15,3 +15,11 @@ schedule_reboot__mail_subject_prefix: '[molecule] '
 # after wait_for_connection, so the default grace sleep would keep the host up past
 # the reconnect and make the check flap. The grace period itself is not under test here.
 schedule_reboot__reboot_grace_period: 0
+
+# Only the mandatory variable of the icinga2_agent role, which this playbook does not
+# run: the downtime request must reach the Icinga2 API all the same. verify.yml runs a
+# stand-in for the API on the host itself, hence localhost.
+icinga2_agent__icinga2_master_cn: 'localhost'
+schedule_reboot__icinga2_api_user_login:
+  username: 'molecule'
+  password: 'linuxfabrik'

--- a/extensions/molecule/schedule_reboot/reboot/verify.yml
+++ b/extensions/molecule/schedule_reboot/reboot/verify.yml
@@ -47,8 +47,9 @@
           class Handler(http.server.BaseHTTPRequestHandler):
               def do_POST(self):
                   body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+                  auth = self.headers.get('Authorization', '').encode()
                   with open(BASE + '/requests.log', 'ab') as f:
-                      f.write(self.path.encode() + b'\n' + body + b'\n')
+                      f.write(self.path.encode() + b'\n' + auth + b'\n' + body + b'\n')
                       f.flush()
                       os.fsync(f.fileno())
                   self.send_response(200)
@@ -147,14 +148,19 @@
 
     # The stand-in is gone with the reboot, its record is not. A request that arrived
     # proves the whole chain: the API URL derived from icinga2_agent__icinga2_master_cn
-    # without the icinga2_agent role in the play, the rendered do-reboot, and curl
-    # reaching the endpoint from schedule-reboot.service. A missing file means that
-    # nothing arrived.
+    # and the credentials from icinga2_master__downtime_api_user, both without their
+    # roles in the play, the rendered do-reboot, and curl reaching the endpoint from
+    # schedule-reboot.service. A missing file means that nothing arrived.
     - name: 'slurp /var/tmp/molecule-icinga2-api/requests.log'
       ansible.builtin.slurp:
         src: '/var/tmp/molecule-icinga2-api/requests.log'
       register: '__molecule__icinga2_api_requests_result'
 
-    - name: 'Assert that do-reboot requested the downtime from the Icinga2 API'
+    - name: 'Assert that do-reboot requested the downtime with the downtime API user'
       ansible.builtin.assert:
-        that: '"/v1/actions/schedule-downtime" in (__molecule__icinga2_api_requests_result["content"] | ansible.builtin.b64decode).splitlines()'
+        that:
+          - '"/v1/actions/schedule-downtime" in __molecule__icinga2_api_requests'
+          - '("Basic " ~ (__molecule__expected_credentials | ansible.builtin.b64encode)) in __molecule__icinga2_api_requests'
+      vars:
+        __molecule__expected_credentials: '{{ icinga2_master__downtime_api_user["username"] }}:{{ icinga2_master__downtime_api_user["password"] }}'
+        __molecule__icinga2_api_requests: '{{ (__molecule__icinga2_api_requests_result["content"] | ansible.builtin.b64decode).splitlines() }}'

--- a/extensions/molecule/schedule_reboot/reboot/verify.yml
+++ b/extensions/molecule/schedule_reboot/reboot/verify.yml
@@ -1,10 +1,85 @@
 # Destructive verify: actually reboot the host through the CLI and confirm it
-# came back (boot_id changed) with an empty spool (tmpfs cleared on reboot), and
-# that the notification do-reboot sent on the way down is a well-formed message.
+# came back (boot_id changed) with an empty spool (tmpfs cleared on reboot), that
+# the notification do-reboot sent on the way down is a well-formed message, and
+# that its downtime request reached the Icinga2 API.
 - name: 'Verify schedule_reboot performs a real reboot'
   hosts: 'systems_under_test'
   gather_facts: false
   tasks:
+
+    # A stand-in for the Icinga2 API on the host itself, listening where the inventory
+    # points (icinga2_agent__icinga2_master_cn: 'localhost'). do-reboot POSTs the
+    # downtime to it on the way down, and the stand-in writes the request to disk before
+    # answering, so it can be read back after the reboot. It has to answer: do-reboot
+    # only limits curl's connect time, so a silent endpoint would stall the reboot.
+    - name: 'mkdir -p /var/tmp/molecule-icinga2-api'
+      ansible.builtin.file:
+        path: '/var/tmp/molecule-icinga2-api'
+        state: 'directory'
+        owner: 'root'
+        group: 'root'
+        mode: 0o700
+
+    # a record left over from an earlier run must not satisfy the assert below
+    - name: 'rm -f /var/tmp/molecule-icinga2-api/requests.log'
+      ansible.builtin.file:
+        path: '/var/tmp/molecule-icinga2-api/requests.log'
+        state: 'absent'
+
+    - name: 'openssl req -x509 -newkey rsa:2048 -nodes -subj /CN=localhost'
+      ansible.builtin.command: >
+        openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj /CN=localhost
+        -keyout /var/tmp/molecule-icinga2-api/key.pem
+        -out /var/tmp/molecule-icinga2-api/cert.pem
+      args:
+        creates: '/var/tmp/molecule-icinga2-api/cert.pem'
+
+    - name: 'Deploy /var/tmp/molecule-icinga2-api/server.py'
+      ansible.builtin.copy:
+        content: |
+          import http.server
+          import os
+          import ssl
+
+          BASE = '/var/tmp/molecule-icinga2-api'
+
+
+          class Handler(http.server.BaseHTTPRequestHandler):
+              def do_POST(self):
+                  body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+                  with open(BASE + '/requests.log', 'ab') as f:
+                      f.write(self.path.encode() + b'\n' + body + b'\n')
+                      f.flush()
+                      os.fsync(f.fileno())
+                  self.send_response(200)
+                  self.send_header('Content-Type', 'application/json')
+                  self.end_headers()
+                  self.wfile.write(b'{"results": []}')
+
+
+          context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+          context.load_cert_chain(BASE + '/cert.pem', BASE + '/key.pem')
+          server = http.server.HTTPServer(('127.0.0.1', 5665), Handler)
+          server.socket = context.wrap_socket(server.socket, server_side=True)
+          server.serve_forever()
+        dest: '/var/tmp/molecule-icinga2-api/server.py'
+        owner: 'root'
+        group: 'root'
+        mode: 0o600
+
+    # the interpreter Ansible itself uses on the host; RHEL 8 has no python3 by default
+    - name: 'systemd-run --unit=molecule-icinga2-api python3 /var/tmp/molecule-icinga2-api/server.py'
+      ansible.builtin.command: >
+        systemd-run --unit=molecule-icinga2-api
+        {{ ansible_facts["discovered_interpreter_python"] | d("/usr/bin/python3") }}
+        /var/tmp/molecule-icinga2-api/server.py
+      changed_when: false
+
+    - name: 'Wait for the Icinga2 API stand-in on 127.0.0.1:5665'
+      ansible.builtin.wait_for:
+        host: '127.0.0.1'
+        port: 5665
+        timeout: 30
 
     - name: 'slurp /proc/sys/kernel/random/boot_id (before)'
       ansible.builtin.slurp:
@@ -69,3 +144,17 @@
         that: '__molecule__expected_from in (__molecule__root_mailbox_result["content"] | ansible.builtin.b64decode)'
       vars:
         __molecule__expected_from: "From: \"[molecule] "
+
+    # The stand-in is gone with the reboot, its record is not. A request that arrived
+    # proves the whole chain: the API URL derived from icinga2_agent__icinga2_master_cn
+    # without the icinga2_agent role in the play, the rendered do-reboot, and curl
+    # reaching the endpoint from schedule-reboot.service. A missing file means that
+    # nothing arrived.
+    - name: 'slurp /var/tmp/molecule-icinga2-api/requests.log'
+      ansible.builtin.slurp:
+        src: '/var/tmp/molecule-icinga2-api/requests.log'
+      register: '__molecule__icinga2_api_requests_result'
+
+    - name: 'Assert that do-reboot requested the downtime from the Icinga2 API'
+      ansible.builtin.assert:
+        that: '"/v1/actions/schedule-downtime" in (__molecule__icinga2_api_requests_result["content"] | ansible.builtin.b64decode).splitlines()'

--- a/extensions/molecule/setup_nextcloud/inventory/group_vars/systems_under_test.yml
+++ b/extensions/molecule/setup_nextcloud/inventory/group_vars/systems_under_test.yml
@@ -4,6 +4,14 @@ coturn__denied_peer_ip: []
 coturn__realm: 'nextcloud.example.com'
 coturn__static_auth_secret: 'linuxfabrik'
 
+# nextcloud__icinga2_api_user_login defaults to this, so the downtime steps of
+# /usr/local/bin/nextcloud-update are rendered. The script itself is not run here: it
+# downloads and applies real Nextcloud updates and restarts notify_push, which this
+# scenario skips.
+icinga2_master__downtime_api_user:
+  username: 'molecule'
+  password: 'linuxfabrik'
+
 mariadb_server__admin_user:
   username: 'mariadb-admin'
   password: 'linuxfabrik'

--- a/roles/borg_local/README.md
+++ b/roles/borg_local/README.md
@@ -123,9 +123,9 @@ borg_local__passphrase: 'linuxfabrik'
 
 `borg_local__icinga2_api_user_login`
 
-* The Icinga2 API User to set the downtime for the corresponding ClamAV service.
+* The Icinga2 API User to set the downtime for the corresponding ClamAV service. Defaults to the downtime API user the `icinga2_master` role creates. When neither is set, no downtime is set.
 * Type: Dictionary.
-* Default: unset
+* Default: `'{{ icinga2_master__downtime_api_user | d({}) }}'`
 
 `borg_local__icinga2_hostname`
 

--- a/roles/borg_local/README.md
+++ b/roles/borg_local/README.md
@@ -119,7 +119,7 @@ borg_local__passphrase: 'linuxfabrik'
 
 * The URL of the Icinga2 API (usually on the Icinga2 Master). This will be used to set a downtime for the corresponding ClamAV service.
 * Type: String.
-* Default: `'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
+* Default: `'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
 
 `borg_local__icinga2_api_user_login`
 

--- a/roles/borg_local/defaults/main.yml
+++ b/roles/borg_local/defaults/main.yml
@@ -34,6 +34,7 @@ borg_local__exclude_files__role_var:
   - file: '*/cache/*'
   - file: '*/log/*'
 borg_local__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+borg_local__icinga2_api_user_login: '{{ icinga2_master__downtime_api_user | d({}) }}'
 borg_local__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 borg_local__include_files__combined_var: '{{ (
       borg_local__include_files__role_var +

--- a/roles/borg_local/defaults/main.yml
+++ b/roles/borg_local/defaults/main.yml
@@ -33,7 +33,7 @@ borg_local__exclude_files__role_var:
   - file: '*.temp'
   - file: '*/cache/*'
   - file: '*/log/*'
-borg_local__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+borg_local__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
 borg_local__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 borg_local__include_files__combined_var: '{{ (
       borg_local__include_files__role_var +

--- a/roles/icinga2_master/README.md
+++ b/roles/icinga2_master/README.md
@@ -107,6 +107,15 @@ icinga2_master__influxdb_login:
 * Type: String.
 * Default: `'{{ ansible_facts["nodename"] }}'`
 
+`icinga2_master__downtime_api_user`
+
+* An Icinga2 API user that may only schedule and remove downtimes (`actions/schedule-downtime`, `actions/remove-downtime`). The [borg_local](https://github.com/Linuxfabrik/lfops/tree/main/roles/borg_local), [nextcloud](https://github.com/Linuxfabrik/lfops/tree/main/roles/nextcloud), [schedule_reboot](https://github.com/Linuxfabrik/lfops/tree/main/roles/schedule_reboot) and [tools](https://github.com/Linuxfabrik/lfops/tree/main/roles/tools) roles use it by default to set a downtime around a backup, a Nextcloud update or a reboot, unless their own `*__icinga2_api_user_login` is set.
+* Set it in `group_vars` that cover the Icinga2 master and every monitored host, since the monitored hosts read it as well. With the `linuxfabrik.lfops.bitwarden_item` lookup, pass a fixed `hostname` instead of `inventory_hostname`, so that all hosts get the same credential.
+* If `icinga2_master__api_users__*_var` contains an API user with the same `username`, both end up as one `ApiUser` and the keys set in that inventory entry win. A different `password` there makes the downtime requests of the other roles fail, and a `permissions` list there replaces the two downtime permissions, so include them when adding more. An API user with a different `username` is left alone; remove it once no host uses it any more.
+* Must be a different user than `icinga2_master__enrolment_api_user`.
+* Type: Dictionary.
+* Default: unset
+
 `icinga2_master__influxdb_database_name`
 
 * The name of the InfluxDB database.
@@ -155,13 +164,6 @@ icinga2_master__api_users__host_var:
     permissions:
       - 'objects/query/*'
       - 'status/query'
-  - username: 'downtime-user'
-    password: 'linuxfabrik'
-    permissions:
-      - 'actions/schedule-downtime'
-      - 'actions/remove-downtime'
-      - 'actions/reschedule-check'
-    state: 'present'
   - username: 'ticket-user'
     password: 'linuxfabrik'
     permissions:
@@ -181,6 +183,9 @@ icinga2_master__api_users__host_var:
     state: 'present'
 icinga2_master__bind_host: '192.0.2.12'
 icinga2_master__cn: '{{ ansible_facts["nodename"] }}'
+icinga2_master__downtime_api_user:
+  username: 'downtime-user'
+  password: 'linuxfabrik'
 icinga2_master__influxdb_database_name: 'icinga2'
 icinga2_master__influxdb_host: 'localhost'
 icinga2_master__influxdb_retention: '216d'

--- a/roles/icinga2_master/defaults/main.yml
+++ b/roles/icinga2_master/defaults/main.yml
@@ -17,6 +17,19 @@ icinga2_master__api_users__role_var:
     password: '{{ icinga2_master__enrolment_api_user["password"] }}'
     permissions:
       - 'actions/generate-ticket'
+  # only rendered when icinga2_master__downtime_api_user is set. the two permissions are
+  # the actions the downtime scripts of borg_local, nextcloud, schedule_reboot and tools
+  # call. verified against Icinga2 2.14.6 on Debian 13: they suffice for a host downtime
+  # with all_services and for its removal, and generate-ticket is refused
+  - username: '{{ icinga2_master__downtime_api_user["username"] | d("") }}'
+    password: '{{ icinga2_master__downtime_api_user["password"] | d("") }}'
+    permissions:
+      - 'actions/remove-downtime'
+      - 'actions/schedule-downtime'
+    state: '{{
+        (icinga2_master__downtime_api_user is defined and icinga2_master__downtime_api_user | length > 0)
+        | ternary("present", "absent")
+      }}'
 icinga2_master__cn: '{{ ansible_facts["nodename"] }}'
 icinga2_master__influxdb_database_name: 'icinga2'
 icinga2_master__influxdb_enable_ha: false

--- a/roles/icinga2_master/tasks/main.yml
+++ b/roles/icinga2_master/tasks/main.yml
@@ -6,6 +6,21 @@
     - 'icinga2_master'
 
 
+# both users are rendered from icinga2_master__api_users__role_var, where the same
+# username would merge them into one ApiUser whose downtime permissions replace
+# actions/generate-ticket
+- name: 'Assert that the downtime API user is not the enrolment API user'
+  ansible.builtin.assert:
+    that:
+      - 'icinga2_master__downtime_api_user["username"] != icinga2_master__enrolment_api_user["username"]'
+    quiet: true
+    fail_msg: 'icinga2_master__downtime_api_user and icinga2_master__enrolment_api_user must be different API users. With the same username, the downtime permissions replace actions/generate-ticket and new agents can no longer be enrolled.'
+  when:
+    - 'icinga2_master__downtime_api_user is defined and icinga2_master__downtime_api_user | length > 0'
+  tags:
+    - 'always'
+
+
 - block:
 
   - name: 'install OS-specific prerequisite packages # ensures correct %post ordering before the main package list is installed'

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -205,7 +205,7 @@ nextcloud__users:
 
 * The URL of the Icinga2 API (usually on the Icinga2 Master). This will be used to set a downtime for the corresponding host and all its services in the `/usr/local/bin/nextcloud-update` script.
 * Type: String.
-* Default: `'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
+* Default: `'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
 
 `nextcloud__icinga2_api_user_login`
 

--- a/roles/nextcloud/README.md
+++ b/roles/nextcloud/README.md
@@ -209,9 +209,9 @@ nextcloud__users:
 
 `nextcloud__icinga2_api_user_login`
 
-* The Icinga2 API User to set the downtime for the corresponding host and all its services in the `/usr/local/bin/nextcloud-update` script.
+* The Icinga2 API User to set the downtime for the corresponding host and all its services in the `/usr/local/bin/nextcloud-update` script. Defaults to the downtime API user the `icinga2_master` role creates. When neither is set, no downtime is set.
 * Type: Dictionary.
-* Default: `'{{ system_update__icinga2_api_user_login }}'`
+* Default: `'{{ icinga2_master__downtime_api_user | d({}) }}'`
 
 `nextcloud__icinga2_hostname`
 

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -169,7 +169,7 @@ nextcloud__database_name: 'nextcloud'
 nextcloud__datadir: '/data'
 
 nextcloud__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
-nextcloud__icinga2_api_user_login: '{{ system_update__icinga2_api_user_login }}'
+nextcloud__icinga2_api_user_login: '{{ icinga2_master__downtime_api_user | d({}) }}'
 nextcloud__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 
 nextcloud__jobs_timeout_start_sec: '10m'

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -168,7 +168,7 @@ nextcloud__database_name: 'nextcloud'
 
 nextcloud__datadir: '/data'
 
-nextcloud__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+nextcloud__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
 nextcloud__icinga2_api_user_login: '{{ system_update__icinga2_api_user_login }}'
 nextcloud__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 

--- a/roles/nextcloud/meta/argument_specs.yml
+++ b/roles/nextcloud/meta/argument_specs.yml
@@ -12,7 +12,6 @@
 # playbook context is assembled (other roles' defaults / gathered facts). declaring them
 # would force those references to resolve on every role entry, even for tag runs that
 # never touch the feature, so they are validated in the tasks where they are used instead:
-#   * nextcloud__icinga2_api_user_login -> '{{ system_update__icinga2_api_user_login }}'
 #   * nextcloud__icinga2_hostname        -> '{{ ansible_facts["nodename"] }}'
 #   * nextcloud__mail_from               -> '{{ mailto_root__from }}'
 #   * nextcloud__mariadb_login           -> '{{ mariadb_server__admin_user }}'
@@ -89,6 +88,11 @@ argument_specs:
         type: 'str'
         required: false
         description: 'The URL of the Icinga2 API used to set a downtime during a server update.'
+
+      nextcloud__icinga2_api_user_login:
+        type: 'dict'
+        required: false
+        description: 'The Icinga2 API user (username/password) used to set a downtime during a Nextcloud update. Defaults to icinga2_master__downtime_api_user; downtime is skipped when neither is set.'
 
       nextcloud__mail_recipients:
         type: 'list'

--- a/roles/schedule_reboot/README.md
+++ b/roles/schedule_reboot/README.md
@@ -63,7 +63,7 @@ Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/RE
 
 * The URL of the Icinga2 API (usually on the Icinga2 Master). Used to set a downtime for the host and all its services around the reboot.
 * Type: String.
-* Default: `'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
+* Default: `'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
 
 `schedule_reboot__icinga2_api_user_login`
 

--- a/roles/schedule_reboot/README.md
+++ b/roles/schedule_reboot/README.md
@@ -13,7 +13,7 @@ Other roles reuse this mechanism instead of rebooting themselves: they drop a re
 * **One reboot window.** `schedule_reboot__reboot_time__*` sets a single time of day at which the actor runs. Steer it per inventory group, for example an earlier window for infrastructure hosts so they reboot before the rest. Without an explicit value each host is assigned a deterministic minute within `04:00`-`04:59` (seeded by its hostname), so a fleet does not reboot in lockstep.
 * **Reboots are modelled as state.** A pending reboot is a file in `/run/schedule-reboot/`; the file name is a category and its content is included in the notification mail. Several pending reasons coalesce into a single reboot. The spool lives on tmpfs, so it clears on the reboot itself.
 * **Producers order themselves before the actor.** A role that runs work at the same window (such as a system update) declares its unit `Before=schedule-reboot.service` (order-only, no `Wants=`/`Requires=`). systemd then runs the reboot only after that work finishes; on a window where no producer runs, the actor runs alone and reboots only if a request is pending.
-* **An Icinga downtime is set around the reboot.** When `schedule_reboot__icinga2_api_user_login` is set, the actor schedules a short host downtime before rebooting, so the reboot does not raise alerts. Without it, the reboot happens without a downtime.
+* **An Icinga downtime is set around the reboot.** When `schedule_reboot__icinga2_api_user_login` or the downtime API user of the `icinga2_master` role (`icinga2_master__downtime_api_user`) is set, the actor schedules a short host downtime before rebooting, so the reboot does not raise alerts. Without it, the reboot happens without a downtime.
 * **Changing the window means redeploying the producers.** Producers might render the window into their own systemd timers at deploy time. Running this role alone after a change therefore moves the actor but leaves those timers on the old window, so the work runs at the old time while the host reboots at the new one. Run the producers in the same play, for example via the [system_update](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/system_update.yml) playbook.
 
 To request a reboot from a script or by hand:
@@ -67,9 +67,9 @@ Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/RE
 
 `schedule_reboot__icinga2_api_user_login`
 
-* The Icinga2 API user used to set the downtime around the reboot. When unset, no downtime is scheduled.
+* The Icinga2 API user used to set the downtime around the reboot. Defaults to the downtime API user the `icinga2_master` role creates. When neither is set, no downtime is scheduled.
 * Type: Dictionary.
-* Default: unset
+* Default: `'{{ icinga2_master__downtime_api_user | d({}) }}'`
 * Subkeys:
 
     * `username`:

--- a/roles/schedule_reboot/defaults/main.yml
+++ b/roles/schedule_reboot/defaults/main.yml
@@ -1,5 +1,6 @@
 schedule_reboot__enabled: true
 schedule_reboot__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+schedule_reboot__icinga2_api_user_login: '{{ icinga2_master__downtime_api_user | d({}) }}'
 schedule_reboot__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 schedule_reboot__mail_from: '{{ mailto_root__from }}'
 schedule_reboot__mail_recipients: '{{ mailto_root__to }}'

--- a/roles/schedule_reboot/defaults/main.yml
+++ b/roles/schedule_reboot/defaults/main.yml
@@ -1,5 +1,5 @@
 schedule_reboot__enabled: true
-schedule_reboot__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+schedule_reboot__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
 schedule_reboot__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 schedule_reboot__mail_from: '{{ mailto_root__from }}'
 schedule_reboot__mail_recipients: '{{ mailto_root__to }}'

--- a/roles/schedule_reboot/meta/argument_specs.yml
+++ b/roles/schedule_reboot/meta/argument_specs.yml
@@ -16,7 +16,7 @@ argument_specs:
       schedule_reboot__icinga2_api_user_login:
         type: 'dict'
         required: false
-        description: 'The Icinga2 API user (username/password) used to set the downtime. Downtime is skipped when unset.'
+        description: 'The Icinga2 API user (username/password) used to set the downtime. Defaults to icinga2_master__downtime_api_user; downtime is skipped when neither is set.'
 
       schedule_reboot__icinga2_hostname:
         type: 'str'

--- a/roles/tools/README.md
+++ b/roles/tools/README.md
@@ -63,9 +63,9 @@ Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/RE
 
 `tools__icinga2_api_user_login`
 
-* The Icinga2 API User to set the downtime for the corresponding host and all its services in the `reboot` alias.
+* The Icinga2 API User to set the downtime for the corresponding host and all its services in the `reboot` alias. Defaults to the downtime API user the `icinga2_master` role creates. When neither is set, the alias sets no downtime.
 * Type: Dictionary.
-* Default: unset
+* Default: `'{{ icinga2_master__downtime_api_user | d({}) }}'`
 
 `tools__icinga2_hostname`
 

--- a/roles/tools/README.md
+++ b/roles/tools/README.md
@@ -59,7 +59,7 @@ Any [LFOps playbook](https://github.com/Linuxfabrik/lfops/blob/main/playbooks/RE
 
 * The URL of the Icinga2 API (usually on the Icinga2 Master). This will be used to set a downtime for the corresponding host and all its services in the `reboot` alias.
 * Type: String.
-* Default: `'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
+* Default: `'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'`
 
 `tools__icinga2_api_user_login`
 

--- a/roles/tools/defaults/main.yml
+++ b/roles/tools/defaults/main.yml
@@ -1,4 +1,5 @@
 tools__editor: 'nano'
 tools__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+tools__icinga2_api_user_login: '{{ icinga2_master__downtime_api_user | d({}) }}'
 tools__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 tools__prompt_use_fqdn: false

--- a/roles/tools/defaults/main.yml
+++ b/roles/tools/defaults/main.yml
@@ -1,4 +1,4 @@
 tools__editor: 'nano'
-tools__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d("") }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
+tools__icinga2_api_url: 'https://{{ icinga2_agent__icinga2_master_host | d(icinga2_agent__icinga2_master_cn | d("")) }}:{{ icinga2_agent__icinga2_master_port | d(5665) }}'
 tools__icinga2_hostname: '{{ ansible_facts["nodename"] }}'
 tools__prompt_use_fqdn: false


### PR DESCRIPTION
## What

Four roles set an Icinga downtime from a script they deploy: `borg_local` (`borg-backup`), `nextcloud` (`nextcloud-update`), `schedule_reboot` (`do-reboot`) and `tools` (the `reboot` alias). Two things kept that downtime from being set, and both went unnoticed because the scripts call curl with `--silent` and send its output to `/dev/null`.

### The API URL (ed950430)

The URL was built from `icinga2_agent__icinga2_master_host` alone. That variable only has a value in a play that also runs `icinga2_agent`, whose default falls back to `icinga2_agent__icinga2_master_cn`, or when the inventory sets it. Since the CN became the mandatory variable, most inventories only set the CN, so every playbook without `icinga2_agent` (`bootloader`, `borg_local`, `crypto_policy`, `kernel_modules`, `schedule_reboot`, `selinux`, `system_update`, `tools`) rendered `https://:5665`. Hosts set up with `setup_basic` got the right URL until the next standalone run overwrote it.

The four roles now use the same chain `icinga2_agent` uses itself: the host if set, the CN otherwise.

### The API user (3dfa02b1)

Each role had its own login variable, unset by default, except `nextcloud`, whose default still pointed at `system_update__icinga2_api_user_login`, removed in v8.0.0. A default that references an undefined variable counts as undefined, so the template guards dropped both downtime steps of `nextcloud-update` without an error.

The optional `icinga2_master__downtime_api_user` makes `icinga2_master` create an `ApiUser` with only `actions/schedule-downtime` and `actions/remove-downtime`, next to the enrolment user in `icinga2_master__api_users__role_var`. The four roles default their `*__icinga2_api_user_login` to `'{{ icinga2_master__downtime_api_user | d({}) }}'`. A role-specific value still wins, and with nothing set the value is `{}` and the scripts skip the downtime as before.

* The entry is switched by its `state` key, so `api-users.conf.j2` is unchanged. A same-named entry in `icinga2_master__api_users__*_var` merges with it through `combine_lod` and its keys win; the README documents this and the different-name case.
* An assert tagged `always` refuses the enrolment user's username, since both entries would merge and the downtime permissions would replace `actions/generate-ticket`.
* The `| d({})` is required: `schedule_reboot` declares the login in `argument_specs`, where a bare reference to an undefined variable aborts at role entry. `nextcloud` now declares it as well.
* The variable belongs in `group_vars` that cover the master and every monitored host, since the monitored hosts read it too.

No breaking change: the new variable is optional, and nothing changes on a host until it is set.

## Testing

* `schedule_reboot/reboot` (destructive) on `rocky8-vm`, `rocky10-vm` and `debian13-vm`. The inventory sets only `icinga2_agent__icinga2_master_cn: 'localhost'` and `icinga2_master__downtime_api_user`; the playbook runs neither of their roles. `verify.yml` starts a TLS stand-in for the Icinga2 API on the host that writes every request to disk, triggers the real reboot, and asserts afterwards that `do-reboot` POSTed `/v1/actions/schedule-downtime` with the central credentials. Passes on all three, so SELinux does not block the curl from `schedule-reboot.service` on the Rocky hosts either. With the previous default the URL renders as `https://:5665` and nothing arrives.
* `setup_nextcloud` on `rocky9-vm`: `converge` and `verify` pass with the downtime user set, so `nextcloud-update` renders its downtime steps and the newly declared `argument_specs` option accepts the value. `idempotence` fails on nine tasks outside this change (listed below); `nextcloud-update` itself stays `ok` on the second pass.
* `api-users.conf` rendered from the role's defaults and template in four cases: variable unset (enrolment user only), set (second user with the two permissions), a same-named inventory entry (its password and permissions win), and the enrolment user's name (the assert aborts before anything is written).
* The rendered downtime user against Icinga2 2.14.6 on Debian 13 (Icinga2 has no RHEL-family package without a subscription), using the request bodies the scripts send: it schedules a host downtime with `all_services` (the response lists the service downtime) and removes it, and `generate-ticket` is refused. This matches `lib/remote/actionshandler.cpp`, which only checks `actions/<name>` (v2.16).
* The `is defined` behaviour and the `argument_specs` abort were checked with ansible-core 2.16.18.
* pre-commit clean; ansible-lint reports nothing new in the changed lines.

## Not in this PR

* No Molecule scenario exists for `icinga2_master`, so the user creation is covered by the render and container tests only.
* `nextcloud-update` is not run in Molecule: it downloads and applies real Nextcloud updates and restarts `notify_push`, which the scenario skips.
* The downtime scripts limit only curl's connect time (`--connect-timeout 5`). An API that accepts the connection but never answers would stall the reboot.
* The nine non-idempotent `setup_nextcloud` tasks: `apache_httpd : chown -R apache:apache /var/www/html`, `collabora : chown -R cool:cool /etc/coolwsd`, `collabora : touch /var/log/coolwsd.log & chmod 0660 /var/log/coolwsd.log`, `nextcloud : restart php-fpm` (twice), `nextcloud : restorecon -Fvr /data /var/www/html/nextcloud`, `nextcloud : Set background job to "cron"`, `redis : Deploy /etc/redis/redis.conf (v8.8)`, `systemd_unit : meta`. Not yet checked against `main`.
